### PR TITLE
Skip devices without I/O

### DIFF
--- a/dool
+++ b/dool
@@ -833,7 +833,7 @@ class dool_disk(dstat):
         ret = []
         for l in self.splitlines():
             if len(l) < 13: continue
-            if l[3:] == ['0',] * 11: continue
+            if l[3:] == ['0',] * (len(l) - 3): continue
             name = l[2]
             ret.append(name)
         for item in objlist: ret.append(item)


### PR DESCRIPTION
Linux 4.18+ has added more fields to the diskstats proc file, so the
original skip condition for devices without I/O didn't apply anymore.

Before:
```
$ ./dool -af 1 5
Terminal width too small, trimming output.
--total-cpu-usage-- -dsk/loop0---dsk/loop1---dsk/loop2---dsk/loop3---dsk/loop4---dsk/loop5---dsk/loop6---dsk/loop7----dsk/sda-----dsk/sdb-- net/docker0--net/wlp2s0>
usr sys idl wai stl| read  writ: read  writ: read  writ: read  writ: read  writ: read  writ: read  writ: read  writ: read  writ: read  writ| recv  send: recv  send>
 24   8  69   0   0|   0     0 :   0     0 :   0     0 :   0     0 :   0     0 :   0     0 :   0     0 :   0     0 : 660k  982k: 138b 1467k|   0     0 :   0     0 >
  4   3  85   8   0|   0     0 :   0     0 :   0     0 :   0     0 :   0     0 :   0     0 :   0     0 :   0     0 :   0     0 :   0   312M|   0     0 :5328b 3744b>
  4   2  84  10   0|   0     0 :   0     0 :   0     0 :   0     0 :   0     0 :   0     0 :   0     0 :   0     0 :   0     0 :   0   317M|   0     0 :5432b 3784b>
  4   1  85   9   0|   0     0 :   0     0 :   0     0 :   0     0 :   0     0 :   0     0 :   0     0 :   0     0 :   0     0 :   0   315M|   0     0 :2704b 1104b>
  4   3  82  11   0|   0     0 :   0     0 :   0     0 :   0     0 :   0     0 :   0     0 :   0     0 :   0     0 :   0     0 :   0   315M|   0     0 :2744b 1160b>
```

After:
```
$ ./dool -af 1 5
--total-cpu-usage-- --dsk/sda-----dsk/sdb-- net/docker0--net/wlp2s0 ---paging-- ------memory-usage----- ---system-- ---procs--- ---load-avg--- -----system----
usr sys idl wai stl| read  writ: read  writ| recv  send: recv  send|  in   out | used  free  buff  cach| int   csw |run blk new| 1m   5m  15m |      time     
 24   8  68   0   0| 661k  983k: 138b 1297k|   0     0 :   0     0 | 642B 4495B|5357M  959M  342M 1791M|1083  3476 |  0 1.0 0.4|2.50 2.25 1.57|Sep-30 13:48:32
  3   2  87   8   0|   0     0 :   0   315M|   0     0 :6352b 4872b|   0     0 |5355M  961M  342M 1789M|3617    11k|  0 1.0   0|2.38 2.23 1.56|Sep-30 13:48:33
  6   4  81  10   0|   0     0 :   0   318M|   0     0 :3048b 5016b|   0     0 |5347M  970M  342M 1789M|4034    13k|  0 1.0   0|2.38 2.23 1.56|Sep-30 13:48:34
  6   2  83  10   0|   0   623k:   0   319M|   0     0 :  15k 6184b|   0     0 |5342M  974M  342M 1776M|3809    12k|  0 1.0   0|2.38 2.23 1.56|Sep-30 13:48:35
  4   3  80  14   0|   0     0 :   0   319M|   0     0 :2736b 8280b|   0     0 |5342M  974M  342M 1775M|3605    11k|1.0 1.0   0|2.38 2.23 1.56|Sep-30 13:48:36
```