### PR TITLE
Fix syntax errors

### DIFF
--- a/plugins/dool_mysql_keys.py
+++ b/plugins/dool_mysql_keys.py
@@ -38,7 +38,7 @@ class dstat_plugin(dstat):
             for name in self.vars: self.val[name] = -1
 
         except Exception as e:
-            if op.debug > 1: print('%s: exception' (self.filename, e))
+            if op.debug > 1: print('%s: exception %s' % (self.filename, e))
             for name in self.vars: self.val[name] = -1
 
 # vim:ts=4:sw=4:et

--- a/plugins/dool_squid.py
+++ b/plugins/dool_squid.py
@@ -45,7 +45,7 @@ class dstat_plugin(dstat):
             if op.debug > 1: print('%s: lost pipe to squidclient, %s' % (self.filename, e))
             for name in self.vars: self.val[name] = -1
         except Exception as e:
-            if op.debug > 1: print('%s: exception' (self.filename, e))
+            if op.debug > 1: print('%s: exception %s' % (self.filename, e))
             for name in self.vars: self.val[name] = -1
 
 # vim:ts=4:sw=4:et


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix pull-request

##### DSTAT VERSION
```
Dool 0.9.9
Written by Scott Baker <scott@perturb.org>
Forked from Dstat written by Dag Wieers <dag@wieers.com>
Homepage at https://github.com/scottchiefbaker/dool/

Platform posix/linux2
Kernel 5.8.0-1-amd64
Python 2.7.16 (default, Oct 10 2019, 22:02:15) 
[GCC 8.3.0]

Terminal type: xterm-256color (color support)
Terminal size: 70 lines, 255 columns

Processors: 8
Pagesize: 4096
Clock ticks per secs: 100

internal:
	aio,cpu,cpu-adv,cpu-use,cpu24,disk,disk24,disk24-old,epoch,fs,int,int24,io,ipc,load,lock,mem,mem-adv,net,page,page24,proc,raw,socket,swap,swap-old,sys,tcp,time,udp,unix,vm,vm-adv,zones
/home/cgrigis/C4DT/Projects/dool/plugins:
	battery,battery-remain,condor-queue,cpufreq,dbus,disk-avgqu,disk-avgrq,disk-svctm,disk-tps,disk-util,disk-wait,dool,dool-cpu,dool-ctxt,dool-mem,fan,freespace,fuse,gpfs,gpfs-ops,helloworld,ib,innodb-buffer,innodb-io,
	innodb-ops,jvm-full,jvm-vm,lustre,md-status,memcache-hits,mongodb-conn,mongodb-mem,mongodb-opcount,mongodb-queue,mongodb-stats,mysql-io,mysql-keys,mysql5-cmds,mysql5-conn,mysql5-innodb,mysql5-innodb-basic,mysql5-innodb-extra,
	mysql5-io,mysql5-keys,net-packets,nfs3,nfs3-ops,nfsd3,nfsd3-ops,nfsd4-ops,nfsstat4,ntp,postfix,power,proc-count,qmail,redis,rpc,rpcd,sendmail,snmp-cpu,snmp-load,snmp-mem,snmp-net,snmp-net-err,snmp-sys,snooze,squid,test,
	thermal,top-bio,top-bio-adv,top-childwait,top-cpu,top-cpu-adv,top-cputime,top-cputime-avg,top-int,top-io,top-io-adv,top-latency,top-latency-avg,top-mem,top-oom,utmp,vm-cpu,vm-mem,vm-mem-adv,vmk-hba,vmk-int,vmk-nic,vz-cpu,
	vz-io,vz-ubc,wifi,zfs-arc,zfs-l2arc,zfs-zil
```

##### SUMMARY
When installing `dstat` from the Debian repositories:
```
(...)
Setting up dstat (0.7.4-6) ...
/usr/share/dstat/dstat_mysql_keys.py:41: SyntaxWarning: 'str' object is not callable; perhaps you missed a comma?
  if op.debug > 1: print('%s: exception' (self.filename, e))
/usr/share/dstat/dstat_squid.py:48: SyntaxWarning: 'str' object is not callable; perhaps you missed a comma?
  if op.debug > 1: print('%s: exception' (self.filename, e))
(...)
```
I traced it down to `dstat` on GitHub, and then to here. :)