### PR TITLE
Key for key in dool_disk_avgqu.py to avoid KeyError

### DIFF
--- a/plugins/dool_disk_avgqu.py
+++ b/plugins/dool_disk_avgqu.py
@@ -60,6 +60,10 @@ class dstat_plugin(dstat):
             )
 
         for name in self.vars:
+            # Avoid KeyError: 'rq_ticks'
+            # See https://bugs.gentoo.org/784704
+            if 'rq_ticks' not in self.set1[name] or 'rq_ticks' not in self.set2[name]:
+                continue
             self.val[name] = ( ( self.set2[name]['rq_ticks'] - self.set1[name]['rq_ticks'] ) * 1.0 / elapsed / 1000, )
 
         if step == op.delay:


### PR DESCRIPTION
Running "make test" may fail with:

Traceback (most recent call last):
  File "./dool", line 2899, in <module>
    main()
  File "./dool", line 2751, in main
    scheduler.run()
  File "/usr/lib/python3.7/sched.py", line 151, in run
    action(*argument, **kwargs)
  File "./dool", line 2847, in perform
    o.extract()
  File "<string>", line 63, in extract
KeyError: 'rq_ticks'
make: *** [Makefile:38: test] Error 1

See https://bugs.gentoo.org/784704