### PR TITLE
Add SIGINT/SIGTERM/SIGHUP/SIGBREAK handler to fix missing data issue in --output mode

### DIFF
--- a/dool
+++ b/dool
@@ -1787,6 +1787,12 @@ class dool_zones(dstat):
 
 ### END STATS DEFINITIONS ###
 
+def signal_handler(signum, frame):
+    if op.output:
+        outputfile.flush()
+    sys.stdout.flush()    
+    sys.exit(0)
+
 def fcolor(num):
    ret = "\033[38;5;" + str(num) + "m"
 
@@ -2598,6 +2604,9 @@ def main():
     global totlist, inittime
     global update, missed
 
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+
     cpunr = getcpunr()
     hz = os.sysconf('SC_CLK_TCK')
     try:
@@ -2900,17 +2909,8 @@ def stripcolor(self, mystr):
 
     return ret
 
-def signal_handler(signum, frame):
-    print('\nStopping dool...', file=sys.stderr)
-    if op.output:
-        outputfile.flush()
-    sys.stdout.flush()    
-    sys.exit(0)
-
 ### Main entrance
 if __name__ == '__main__':
-    signal.signal(signal.SIGINT, signal_handler)
-    signal.signal(signal.SIGTERM, signal_handler)
     try:
         initterm()
         op = Options(os.getenv('DOOL_OPTS','').split() + sys.argv[1:])

--- a/dool
+++ b/dool
@@ -2607,7 +2607,7 @@ def main():
 
     if os.name == 'nt':
         signal.signal(signal.SIGBREAK, signal_handler)
-    else if os.name == 'posix':
+    elif os.name == 'posix':
         signal.signal(signal.SIGHUP, signal_handler)
     signal.signal(signal.SIGINT, signal_handler)
     signal.signal(signal.SIGTERM, signal_handler)

--- a/dool
+++ b/dool
@@ -2605,6 +2605,10 @@ def main():
     global totlist, inittime
     global update, missed
 
+    if os.name == 'nt':
+        signal.signal(signal.SIGBREAK, signal_handler)
+    else if os.name == 'posix':
+        signal.signal(signal.SIGHUP, signal_handler)
     signal.signal(signal.SIGINT, signal_handler)
     signal.signal(signal.SIGTERM, signal_handler)
 

--- a/dool
+++ b/dool
@@ -1790,7 +1790,8 @@ class dool_zones(dstat):
 def signal_handler(signum, frame):
     if op.output:
         outputfile.flush()
-    sys.stdout.flush()    
+    print('\n')
+    sys.stdout.flush()
     sys.exit(0)
 
 def fcolor(num):

--- a/dool
+++ b/dool
@@ -30,6 +30,7 @@ import resource
 import sched
 import sys
 import time
+import signal
 
 # https://stackoverflow.com/questions/53978542/how-to-use-collections-abc-from-both-python-3-8-and-python-2-7
 try:
@@ -2899,8 +2900,17 @@ def stripcolor(self, mystr):
 
     return ret
 
+def signal_handler(signum, frame):
+    print('\nStopping dool...', file=sys.stderr)
+    if op.output:
+        outputfile.flush()
+    sys.stdout.flush()    
+    sys.exit(0)
+
 ### Main entrance
 if __name__ == '__main__':
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
     try:
         initterm()
         op = Options(os.getenv('DOOL_OPTS','').split() + sys.argv[1:])


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix pull-request

##### DSTAT VERSION
```
0.9.10
```

##### SUMMARY
<!--- Describe the change here, including rationale and design decisions -->
Add a SIGINT and SIGTERM handler so the data still in the I/O buffer will be written out before exiting the program.
