### PR TITLE
/proc/diskstats: better detection of unused block devices

### DIFF
--- a/dool
+++ b/dool
@@ -825,7 +825,7 @@ class dool_disk(dstat):
         ret = []
         for l in self.splitlines():
             if len(l) < 13: continue
-            if l[3:] == ['0',] * 11: continue
+            if set(l[3:]) == {'0'}: continue
             name = l[2]
             ret.append(name)
         for item in objlist: ret.append(item)
@@ -882,7 +882,7 @@ class dool_disk(dstat):
             if len(l) < 13: continue
             if l[5] == '0' and l[9] == '0': continue
             name = l[2]
-            if l[3:] == ['0',] * 11: continue
+            if set(l[3:]) == {'0'}: continue
             if not self.diskfilter.match(name):
                 self.set2['total'] = ( self.set2['total'][0] + int(l[5]), self.set2['total'][1] + int(l[9]) )
             if name in self.vars and name != 'total':
@@ -1248,7 +1248,7 @@ class dool_io(dstat):
         ret = []
         for l in self.splitlines():
             if len(l) < 13: continue
-            if l[3:] == ['0',] * 11: continue
+            if set(l[3:]) == {'0'}: continue
             name = l[2]
             ret.append(name)
         for item in objlist: ret.append(item)
@@ -1284,7 +1284,7 @@ class dool_io(dstat):
             if len(l) < 13: continue
             if l[3] == '0' and l[7] == '0': continue
             name = l[2]
-            if l[3:] == ['0',] * 11: continue
+            if set(l[3:]) == {'0'}: continue
             if not self.diskfilter.match(name):
                 self.set2['total'] = ( self.set2['total'][0] + int(l[3]), self.set2['total'][1] + int(l[7]) )
             if name in self.vars and name != 'total':

--- a/plugins/dool_disk_avgqu.py
+++ b/plugins/dool_disk_avgqu.py
@@ -20,7 +20,7 @@ class dstat_plugin(dstat):
         ret = []
         for l in self.splitlines():
             if len(l) < 13: continue
-            if l[3:] == ['0',] * 11: continue
+            if set(l[3:]) == {'0'}: continue
             name = l[2]
             ret.append(name)
         for item in objlist: ret.append(item)
@@ -51,7 +51,7 @@ class dstat_plugin(dstat):
     def extract(self):
         for l in self.splitlines():
             if len(l) < 13: continue
-            if l[3:] == ['0',] * 11: continue
+            if set(l[3:]) == {'0'}: continue
             if l[3] == '0' and l[7] == '0': continue
             name = l[2]
             if name not in self.vars or name == 'total': continue

--- a/plugins/dool_disk_avgrq.py
+++ b/plugins/dool_disk_avgrq.py
@@ -21,7 +21,7 @@ class dstat_plugin(dstat):
         ret = []
         for l in self.splitlines():
             if len(l) < 13: continue
-            if l[3:] == ['0',] * 11: continue
+            if set(l[3:]) == {'0'}: continue
             name = l[2]
             ret.append(name)
         for item in objlist: ret.append(item)
@@ -52,7 +52,7 @@ class dstat_plugin(dstat):
     def extract(self):
         for l in self.splitlines():
             if len(l) < 13: continue
-            if l[3:] == ['0',] * 11: continue
+            if set(l[3:]) == {'0'}: continue
             if l[3] == '0' and l[7] == '0': continue
             name = l[2]
             if name not in self.vars or name == 'total': continue

--- a/plugins/dool_disk_svctm.py
+++ b/plugins/dool_disk_svctm.py
@@ -24,7 +24,7 @@ class dstat_plugin(dstat):
         ret = []
         for l in self.splitlines():
             if len(l) < 13: continue
-            if l[3:] == ['0',] * 11: continue
+            if set(l[3:]) == {'0'}: continue
             name = l[2]
             ret.append(name)
         for item in objlist: ret.append(item)
@@ -55,7 +55,7 @@ class dstat_plugin(dstat):
     def extract(self):
         for l in self.splitlines():
             if len(l) < 13: continue
-            if l[3:] == ['0',] * 11: continue
+            if set(l[3:]) == {'0'}: continue
             if l[3] == '0' and l[7] == '0': continue
             name = l[2]
             if name not in self.vars or name == 'total': continue

--- a/plugins/dool_disk_tps.py
+++ b/plugins/dool_disk_tps.py
@@ -20,7 +20,7 @@ class dstat_plugin(dstat):
         ret = []
         for l in self.splitlines():
             if len(l) < 13: continue
-            if l[3:] == ['0',] * 11: continue
+            if set(l[3:]) == {'0'}: continue
             name = l[2]
             ret.append(name)
         for item in objlist: ret.append(item)
@@ -55,7 +55,7 @@ class dstat_plugin(dstat):
         for l in self.splitlines():
             if len(l) < 13: continue
             if l[3] == '0' and l[7] == '0': continue
-            if l[3:] == ['0',] * 11: continue
+            if set(l[3:]) == {'0'}: continue
             name = l[2]
             if not self.diskfilter.match(name):
                 self.set2['total'] = ( self.set2['total'][0] + int(l[3]), self.set2['total'][1] + int(l[7]) )

--- a/plugins/dool_disk_util.py
+++ b/plugins/dool_disk_util.py
@@ -23,7 +23,7 @@ class dstat_plugin(dstat):
         ret = []
         for l in self.splitlines():
             if len(l) < 13: continue
-            if l[3:] == ['0',] * 11: continue
+            if set(l[3:]) == {'0'}: continue
             name = l[2]
             ret.append(name)
         for item in objlist: ret.append(item)
@@ -76,7 +76,7 @@ class dstat_plugin(dstat):
         for l in self.splitlines():
             if len(l) < 13: continue
             if l[5] == '0' and l[9] == '0': continue
-            if l[3:] == ['0',] * 11: continue
+            if set(l[3:]) == {'0'}: continue
             name = l[2]
             if name not in self.vars: continue
             self.set2[name] = dict(

--- a/plugins/dool_disk_wait.py
+++ b/plugins/dool_disk_wait.py
@@ -22,7 +22,7 @@ class dstat_plugin(dstat):
         ret = []
         for l in self.splitlines():
             if len(l) < 13: continue
-            if l[3:] == ['0',] * 11: continue
+            if set(l[3:]) == {'0'}: continue
             name = l[2]
             ret.append(name)
         for item in objlist: ret.append(item)
@@ -54,7 +54,7 @@ class dstat_plugin(dstat):
         for l in self.splitlines():
             if len(l) < 13: continue
             if l[5] == '0' and l[9] == '0': continue
-            if l[3:] == ['0',] * 11: continue
+            if set(l[3:]) == {'0'}: continue
             name = l[2]
             if name not in self.vars: continue
             self.set2[name] = dict(


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix pull-request

##### DSTAT VERSION
```
Dool 1.0.0
Written by Scott Baker <scott@perturb.org>
Forked from Dstat written by Dag Wieers <dag@wieers.com>
Homepage at https://github.com/scottchiefbaker/dool/

Platform posix/linux
Kernel 5.13.12_1
Python 3.10.2 (main, Jan 15 2022, 03:11:32) [GCC 10.2.1 20201203]

Terminal type: rxvt-unicode-256color (color support)
Terminal size: 82 lines, 154 columns

Processors: 8
Pagesize: 4096
Clock ticks per secs: 100

internal:
	aio,cpu,cpu-adv,cpu-use,cpu24,disk,disk24,disk24-old,epoch,fs,int,int24,io,ipc,load,lock,mem,mem-adv,net,page,page24,proc,
	raw,socket,swap,swap-old,sys,tcp,time,udp,unix,vm,vm-adv,zones
/home/leah/src/dool/plugins:
	battery,battery-remain,condor-queue,cpufreq,dbus,disk-avgqu,disk-avgrq,disk-svctm,disk-tps,disk-util,disk-wait,dool,dool-cpu,
	dool-ctxt,dool-mem,fan,freespace,fuse,gpfs,gpfs-ops,helloworld,ib,innodb-buffer,innodb-io,innodb-ops,jvm-full,jvm-vm,lustre,
	md-status,memcache-hits,mongodb-conn,mongodb-mem,mongodb-opcount,mongodb-queue,mongodb-stats,mysql-io,mysql-keys,mysql5-cmds,
	mysql5-conn,mysql5-innodb,mysql5-innodb-basic,mysql5-innodb-extra,mysql5-io,mysql5-keys,net-packets,nfs3,nfs3-ops,nfsd3,nfsd3-ops,
	nfsd4-ops,nfsstat4,ntp,postfix,power,proc-count,qmail,redis,rpc,rpcd,sendmail,snmp-cpu,snmp-load,snmp-mem,snmp-net,snmp-net-err,
	snmp-sys,snooze,squid,test,thermal,top-bio,top-bio-adv,top-childwait,top-cpu,top-cpu-adv,top-cputime,top-cputime-avg,top-int,
	top-io,top-io-adv,top-latency,top-latency-avg,top-mem,top-oom,utmp,vm-cpu,vm-mem,vm-mem-adv,vmk-hba,vmk-int,vmk-nic,vz-cpu,vz-io,
	vz-ubc,wifi,zfs-arc,zfs-l2arc,zfs-zil
```

##### SUMMARY
<!--- Describe the change here, including rationale and design decisions -->

The format of /proc/diskstats has changed over the years:
Until kernel 4.17 there were 14 fields (which this code assumed)
Since 4.18 there are 18 fields, since 5.5 there are 20 fields.

Assume unused devices have all fields zero.

Fixes #1.
Fixes #5.
Fixes #7.

```
% ./dool --disk-wait                      
--loop0----nvme0n1----zram0--                  
rawa wawa:rawa wawa:rawa wawa
0.05    0:0.16 2.46:0.00 0.01
   0    0:   0    0:   0    0
   0    0:   0 1.67:   0    0^C
```