### PR TITLE
El7 packaging

### DIFF
--- a/packaging/el7/build.sh
+++ b/packaging/el7/build.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/bash
+
+red="\033[1;31m"
+white="\033[1;37m"
+reset="\033[0m"
+
+# Extract the version number from the dool script
+export VERSION=`perl -nE 'if (/VERSION = .*?([\.\d]+)/) { print $1; } ' ../../dool`
+
+if [[ -z $VERSION ]]
+then
+	echo "Unable to extract version number from 'dool'"
+	exit 5
+fi
+
+# Change the version number in the spec file
+perl -pi -e "s/Version:.*/Version: $VERSION/" dool.spec
+
+echo "Building version $VERSION";
+sleep 1
+
+# Build a tar archive of the current HEAD with the correct version number
+cd ../../
+git archive --format=tar --prefix=dool-$VERSION/ HEAD | gzip > /tmp/dool-$VERSION.tar.gz
+cp -a /tmp/dool-$VERSION.tar.gz ~/rpmbuild/SOURCES/
+cd -
+
+# Build the actual RPM
+rpmbuild --target noarch -bb dool.spec
+
+# Check if the build was a success
+if [[ $? -eq 0 ]]
+then
+	echo -e $white
+	echo -e "\n* Build successful\n"
+	ls -lsah ~/rpmbuild/RPMS/noarch/dool-$VERSION-1.noarch.rpm
+else
+	echo -e $red
+	echo "Error building RPM... exit code $?"
+fi
+
+echo -e $reset

--- a/packaging/el7/dool.spec
+++ b/packaging/el7/dool.spec
@@ -1,0 +1,137 @@
+# $Id$
+# Authority: Scott Baker
+# Upstream: https://github.com/scottchiefbaker/dool
+
+Summary: Pluggable real-time performance monitoring tool
+Name: dool
+Version: 1.0.0
+Release: 1
+License: GPL
+Group: System Environment/Base
+URL: https://github.com/scottchiefbaker/dool
+
+Source: https://github.com/scottchiefbaker/dool/releases/dool-%{version}.tar.gz
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
+
+BuildArch: noarch
+Requires: python3 >= 3.6 python36-six
+
+%description
+Dool is a versatile replacement for vmstat, iostat, netstat and ifstat.
+Dool overcomes some of their limitations and adds some extra features,
+more counters and flexibility. Dool is handy for monitoring systems
+during performance tuning tests, benchmarks or troubleshooting.
+
+Dool allows you to view all of your system resources in real-time, you
+can eg. compare disk utilization in combination with interrupts from your
+IDE controller, or compare the network bandwidth numbers directly
+with the disk throughput (in the same interval).
+
+Dool gives you detailed selective information in columns and clearly
+indicates in what magnitude and unit the output is displayed. Less
+confusion, less mistakes. And most importantly, it makes it very easy
+to write plugins to collect your own counters and extend in ways you
+never expected.
+
+%prep
+%setup
+
+%build
+
+%install
+%{__rm} -rf %{buildroot}
+%{__make} install DESTDIR="%{buildroot}"
+
+%clean
+%{__rm} -rf %{buildroot}
+
+%files
+%defattr(-, root, root, 0755)
+%doc AUTHORS ChangeLog COPYING README.md TODO docs/*.html docs/*.adoc examples/
+%doc %{_mandir}/man1/dool.1*
+%{_bindir}/dool
+%{_datadir}/dool/
+
+%changelog
+* Mon Nov 29 2021 Scott Baker <scott@perturb.org> - 1.0.0-1
+- Updated to release 1.0.0.
+
+* Fri Aug 23 2019 Scott Baker <scott@perturb.org> - 0.9.9-1
+- Updated to release 0.9.9.
+
+* Fri Mar 18 2016 Dag Wieers <dag@wieers.com> - 0.7.3-1
+- Updated to release 0.7.3.
+
+* Tue Jun 15 2010 Dag Wieers <dag@wieers.com> - 0.7.2-1
+- Updated to release 0.7.2.
+
+* Mon Feb 22 2010 Dag Wieers <dag@wieers.com> - 0.7.1-1
+- Updated to release 0.7.1.
+
+* Wed Nov 25 2009 Dag Wieers <dag@wieers.com> - 0.7.0-1
+- Updated to release 0.7.0.
+- Reduce the number of paths used for importing modules. {CVE-2009-3894}
+
+* Tue Dec 02 2008 Dag Wieers <dag@wieers.com> - 0.6.9-1
+- Updated to release 0.6.9.
+
+* Sun Aug 17 2008 Dag Wieers <dag@wieers.com> - 0.6.8-1
+- Updated to release 0.6.8.
+
+* Tue Feb 26 2008 Dag Wieers <dag@wieers.com> - 0.6.7-1
+- Updated to release 0.6.7.
+
+* Sat Apr 28 2007 Dag Wieers <dag@wieers.com> - 0.6.6-1
+- Updated to release 0.6.6.
+
+* Tue Apr 17 2007 Dag Wieers <dag@wieers.com> - 0.6.5-1
+- Updated to release 0.6.5.
+
+* Tue Dec 12 2006 Dag Wieers <dag@wieers.com> - 0.6.4-1
+- Updated to release 0.6.4.
+
+* Mon Jun 26 2006 Dag Wieers <dag@wieers.com> - 0.6.3-1
+- Updated to release 0.6.3.
+
+* Thu Mar 09 2006 Dag Wieers <dag@wieers.com> - 0.6.2-1
+- Updated to release 0.6.2.
+
+* Mon Sep 05 2005 Dag Wieers <dag@wieers.com> - 0.6.1-1
+- Updated to release 0.6.1.
+
+* Sun May 29 2005 Dag Wieers <dag@wieers.com> - 0.6.0-1
+- Updated to release 0.6.0.
+
+* Fri Apr 08 2005 Dag Wieers <dag@wieers.com> - 0.5.10-1
+- Updated to release 0.5.10.
+
+* Mon Mar 28 2005 Dag Wieers <dag@wieers.com> - 0.5.9-1
+- Updated to release 0.5.9.
+
+* Tue Mar 15 2005 Dag Wieers <dag@wieers.com> - 0.5.8-1
+- Updated to release 0.5.8.
+
+* Fri Dec 31 2004 Dag Wieers <dag@wieers.com> - 0.5.7-1
+- Updated to release 0.5.7.
+
+* Mon Dec 20 2004 Dag Wieers <dag@wieers.com> - 0.5.6-1
+- Updated to release 0.5.6.
+
+* Thu Dec 02 2004 Dag Wieers <dag@wieers.com> - 0.5.5-1
+- Updated to release 0.5.5.
+
+* Thu Nov 25 2004 Dag Wieers <dag@wieers.com> - 0.5.4-1
+- Updated to release 0.5.4.
+- Use dstat15 if distribution uses python 1.5.
+
+* Sun Nov 21 2004 Dag Wieers <dag@wieers.com> - 0.5.3-1
+- Updated to release 0.5.3.
+
+* Sat Nov 13 2004 Dag Wieers <dag@wieers.com> - 0.5.2-1
+- Updated to release 0.5.2.
+
+* Thu Nov 11 2004 Dag Wieers <dag@wieers.com> - 0.5.1-1
+- Updated to release 0.5.1.
+
+* Tue Oct 26 2004 Dag Wieers <dag@wieers.com> - 0.4-1
+- Initial package. (using DAR)


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix pull-request

##### DSTAT VERSION
```
Dool 1.0.0
Written by Scott Baker <scott@perturb.org>
Forked from Dstat written by Dag Wieers <dag@wieers.com>
Homepage at https://github.com/scottchiefbaker/dool/

Platform posix/linux
Kernel 3.10.0-1160.53.1.el7.x86_64
Python 3.6.8 (default, Nov 16 2020, 16:55:22)
[GCC 4.8.5 20150623 (Red Hat 4.8.5-44)]

Terminal type: xterm-256color (color support)
Terminal size: 50 lines, 120 columns

Processors: 8
Pagesize: 4096
Clock ticks per secs: 100

internal:
        aio,cpu,cpu-adv,cpu-use,cpu24,disk,disk24,disk24-old,epoch,fs,int,int24,io,ipc,load,lock,mem,
        mem-adv,net,page,page24,proc,raw,socket,swap,swap-old,sys,tcp,time,udp,unix,vm,vm-adv,zones
/usr/share/dool:
        battery,battery-remain,condor-queue,cpufreq,dbus,disk-avgqu,disk-avgrq,disk-svctm,disk-tps,disk-util,
        disk-wait,dool,dool-cpu,dool-ctxt,dool-mem,fan,freespace,fuse,gpfs,gpfs-ops,helloworld,ib,
        innodb-buffer,innodb-io,innodb-ops,jvm-full,jvm-vm,lustre,md-status,memcache-hits,mongodb-conn,
        mongodb-mem,mongodb-opcount,mongodb-queue,mongodb-stats,mysql-io,mysql-keys,mysql5-cmds,mysql5-conn,
        mysql5-innodb,mysql5-innodb-basic,mysql5-innodb-extra,mysql5-io,mysql5-keys,net-packets,nfs3,nfs3-ops,
        nfsd3,nfsd3-ops,nfsd4-ops,nfsstat4,ntp,postfix,power,proc-count,qmail,redis,rpc,rpcd,sendmail,
        snmp-cpu,snmp-load,snmp-mem,snmp-net,snmp-net-err,snmp-sys,snooze,squid,test,thermal,top-bio,
        top-bio-adv,top-childwait,top-cpu,top-cpu-adv,top-cputime,top-cputime-avg,top-int,top-io,top-io-adv,
        top-latency,top-latency-avg,top-mem,top-oom,utmp,vm-cpu,vm-mem,vm-mem-adv,vmk-hba,vmk-int,vmk-nic,
        vz-cpu,vz-io,vz-ubc,wifi,zfs-arc,zfs-l2arc,zfs-zil
```

##### SUMMARY
Adds a working spec file for building RPM packages on/for EL7. As EL7 and EL8 (and likely SLE) have different versions of python available, I do not think a single spec file will work for all of them. On EL7 dool is well served by python3 3.6.x, so that's the requirement I included in the spec along with the python36 version of six. I've also incremented the dool version number and added a line to the changelog to indicate the release date. I've also removed the BuildRequires option as it does not appear anything else is required on EL7 beyond what is necessary for rpmbuild to function.

I tested this spec file on a CentOS 7 host. The rpmbuild worked as expected, the resulting RPM requested the correct dependencies for a yum install, and dool works after the package is installed.