### PR TITLE
Fix `module 'importlib' has no attribute 'machinery'`  error in Python 3.10.2

### DIFF
--- a/dool
+++ b/dool
@@ -2696,8 +2696,8 @@ def main():
             pluginfile = 'dool_' + mod.replace('-', '_')
             try:
                 if pluginfile not in globals():
-                    import importlib
-                    spec = importlib.machinery.PathFinder.find_spec(pluginfile, pluginpath)
+                    from importlib import machinery
+                    spec = machinery.PathFinder.find_spec(pluginfile, pluginpath)
 
                     ### Try loading python plugin
                     if spec is not None:


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix pull-request

##### DSTAT VERSION
Dool 1.0.0
Written by Scott Baker <scott@perturb.org>
Forked from Dstat written by Dag Wieers <dag@wieers.com>
Homepage at https://github.com/scottchiefbaker/dool/

Platform posix/linux
Kernel 5.16.8-arch1-1
Python 3.10.2 (main, Jan 15 2022, 19:56:27) [GCC 11.1.0]

Terminal type: xterm (color support)
Terminal size: 24 lines, 80 columns

Processors: 32
Pagesize: 4096
Clock ticks per secs: 100

internal:
	aio,cpu,cpu-adv,cpu-use,cpu24,disk,disk24,disk24-old,epoch,
	fs,int,int24,io,ipc,load,lock,mem,mem-adv,net,page,page24,
	proc,raw,socket,swap,swap-old,sys,tcp,time,udp,unix,vm,
	vm-adv,zones
/tmp/dool/plugins:
	battery,battery-remain,condor-queue,cpufreq,dbus,disk-avgqu,
	disk-avgrq,disk-svctm,disk-tps,disk-util,disk-wait,dool,
	dool-cpu,dool-ctxt,dool-mem,fan,freespace,fuse,gpfs,gpfs-ops,
	helloworld,ib,innodb-buffer,innodb-io,innodb-ops,jvm-full,
	jvm-vm,lustre,md-status,memcache-hits,mongodb-conn,mongodb-mem,
	mongodb-opcount,mongodb-queue,mongodb-stats,mysql-io,mysql-keys,
	mysql5-cmds,mysql5-conn,mysql5-innodb,mysql5-innodb-basic,
	mysql5-innodb-extra,mysql5-io,mysql5-keys,net-packets,nfs3,
	nfs3-ops,nfsd3,nfsd3-ops,nfsd4-ops,nfsstat4,ntp,postfix,power,
	proc-count,qmail,redis,rpc,rpcd,sendmail,snmp-cpu,snmp-load,
	snmp-mem,snmp-net,snmp-net-err,snmp-sys,snooze,squid,test,
	thermal,top-bio,top-bio-adv,top-childwait,top-cpu,top-cpu-adv,
	top-cputime,top-cputime-avg,top-int,top-io,top-io-adv,
	top-latency,top-latency-avg,top-mem,top-oom,utmp,vm-cpu,vm-mem,
	vm-mem-adv,vmk-hba,vmk-int,vmk-nic,vz-cpu,vz-io,vz-ubc,wifi,
	zfs-arc,zfs-l2arc,zfs-zil

##### SUMMARY
For some reason, lookup of `importlib.machinery` fails in Python 3.10.2 after `import importlib` (see below).  However the form `from importlib import machinery` works.

Fixes #20

```bash
$ ./dool --top-mem # before
Module dool_top_mem failed to load. (module 'importlib' has no attribute 'machinery')
None of the stats you selected are available.

$ ./dool --top-mem # after
--most-expensive-
  memory process
enlightenmen 131M
enlightenmen 131M
```