### PR TITLE
Add support for Lustre 2.12+ in the `lustre` plugin

### DIFF
--- a/plugins/dool_lustre.py
+++ b/plugins/dool_lustre.py
@@ -1,4 +1,4 @@
-# Author: Brock Palen <brockp@mlds-networks.com>, Kilian Vavalotti <kilian@stanford.edu>
+# Author: Brock Palen <brockp@mlds-networks.com>, Kilian Cavalotti <kilian@stanford.edu>
 
 class dstat_plugin(dstat):
     def __init__(self):


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix pull-request

##### DOOL VERSION
```
Dool 1.0.0
Written by Scott Baker <scott@perturb.org>
Forked from Dstat written by Dag Wieers <dag@wieers.com>
Homepage at https://github.com/scottchiefbaker/dool/

Platform posix/linux
Kernel 3.10.0-1160.62.1.el7.x86_64
Python 3.6.8 (default, Nov 16 2020, 16:55:22)
[GCC 4.8.5 20150623 (Red Hat 4.8.5-44)]

Terminal type: xterm-256color (color support)
Terminal size: 53 lines, 270 columns

Processors: 40
Pagesize: 4096
Clock ticks per secs: 100

internal:
        aio,cpu,cpu-adv,cpu-use,cpu24,disk,disk24,disk24-old,epoch,fs,int,int24,io,ipc,load,lock,mem,mem-adv,net,page,page24,proc,raw,socket,swap,swap-old,sys,tcp,time,udp,unix,vm,vm-adv,zones
/usr/share/dool:
        battery,battery-remain,bond,condor-queue,cpufreq,dbus,disk-avgqu,disk-avgrq,disk-svctm,disk-tps,disk-util,disk-wait,dool,dool-cpu,dool-ctxt,dool-mem,fan,freespace,fuse,gpfs,gpfs-ops,helloworld,ib,innodb-buffer,innodb-io,innodb-ops,
        jvm-full,jvm-vm,lustre,md-status,memcache-hits,mongodb-conn,mongodb-mem,mongodb-opcount,mongodb-queue,mongodb-stats,mysql-io,mysql-keys,mysql5-cmds,mysql5-conn,mysql5-innodb,mysql5-innodb-basic,mysql5-innodb-extra,mysql5-io,mysql5-keys,
        net-packets,nfs3,nfs3-ops,nfsd3,nfsd3-ops,nfsd4-ops,nfsstat4,ntp,postfix,power,proc-count,qmail,redis,rpc,rpcd,sendmail,snmp-cpu,snmp-load,snmp-mem,snmp-net,snmp-net-err,snmp-sys,snooze,squid,test,thermal,top-bio,top-bio-adv,
        top-childwait,top-cpu,top-cpu-adv,top-cputime,top-cputime-avg,top-int,top-io,top-io-adv,top-latency,top-latency-avg,top-mem,top-oom,utmp,vm-cpu,vm-mem,vm-mem-adv,vmk-hba,vmk-int,vmk-nic,vz-cpu,vz-io,vz-ubc,wifi,zfs-arc,zfs-l2arc,
        zfs-zil
```

##### SUMMARY
Add support for Lustre 2.12+ in the `lustre` plugin.
Check for the existence of `/proc/fs/lustre/llite` and `/sys/kernel/debug/lustre/llite` to support both pre-2.12 and post-2.12 client stats.

Also initialize the `read` and `write` values to 0 in case the `stats` file doesn't contain any `read_bytes` or `write_bytes` line. This can happen in case of read-only mounts, or if no IO has been done to the filesystem(s) yet.

Fixes #23.