### PR TITLE
Update Makefile

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -11,13 +11,13 @@ all:
 
 dist: docs
 
-docs: dstat.1 $(htmltargets)
+docs: dool.1 $(htmltargets)
 
-install: dstat.1
-	install -Dp -m0644 dstat.1 $(DESTDIR)$(mandir)/man1/dstat.1
+install: dool.1
+	install -Dp -m0644 dool.1 $(DESTDIR)$(mandir)/man1/dool.1
 
 clean:
-	rm -f dstat.1 *.html *.xml
+	rm -f dool.1 *.html *.xml
 
 %.1.html: %.1.adoc
 	asciidoc -d manpage $<


### PR DESCRIPTION
s/dstat/dool/g

##### ISSUE TYPE
 - Bugfix pull-request

##### DSTAT VERSION
```
$ ./dool --version
Dool 1.1.0
Written by Scott Baker <scott@perturb.org>
Forked from Dstat written by Dag Wieers <dag@wieers.com>
Homepage at https://github.com/scottchiefbaker/dool/

Platform posix/linux
Kernel 6.0.9-arch1-1
Python 3.10.8 (main, Nov  1 2022, 14:18:21) [GCC 12.2.0]

Terminal type: xterm-256color (color support)
Terminal size: 60 lines, 199 columns

Processors: 12
Pagesize: 4096
Clock ticks per secs: 100

internal:
	aio,cpu,cpu-adv,cpu-use,cpu24,disk,disk24,disk24-old,epoch,fs,int,int24,io,ipc,load,lock,mem,mem-adv,net,page,page24,proc,raw,socket,swap,swap-old,sys,tcp,time,
	udp,unix,vm,vm-adv,zones
/home/ambie/src/dool/plugins:
	battery,battery-remain,condor-queue,cpufreq,dbus,disk-avgqu,disk-avgrq,disk-svctm,disk-tps,disk-util,disk-wait,dool,dool-cpu,dool-ctxt,dool-mem,fan,freespace,fuse,gpfs,
	gpfs-ops,helloworld,ib,innodb-buffer,innodb-io,innodb-ops,jvm-full,jvm-vm,lustre,md-status,memcache-hits,mongodb-conn,mongodb-mem,mongodb-opcount,mongodb-queue,mongodb-stats,
	mysql-io,mysql-keys,mysql5-cmds,mysql5-conn,mysql5-innodb,mysql5-innodb-basic,mysql5-innodb-extra,mysql5-io,mysql5-keys,net-packets,nfs3,nfs3-ops,nfsd3,nfsd3-ops,nfsd4-ops,
	nfsstat4,ntp,postfix,power,proc-count,qmail,redis,rpc,rpcd,sendmail,snmp-cpu,snmp-load,snmp-mem,snmp-net,snmp-net-err,snmp-sys,snooze,squid,test,thermal,top-bio,
	top-bio-adv,top-childwait,top-cpu,top-cpu-adv,top-cputime,top-cputime-avg,top-int,top-io,top-io-adv,top-latency,top-latency-avg,top-mem,top-oom,utmp,vm-cpu,vm-mem,
	vm-mem-adv,vmk-hba,vmk-int,vmk-nic,vz-cpu,vz-io,vz-ubc,wifi,zfs-arc,zfs-l2arc,zfs-zil
```

##### SUMMARY
<!--- Describe the change here, including rationale and design decisions -->
It hurts. ow ow ow.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

```
$ make
make -C docs docs
make[1]: Entering directory '/home/ambie/src/dool/docs'
make[1]: *** No rule to make target 'dstat.1', needed by 'docs'.  Stop.
make[1]: Leaving directory '/home/ambie/src/dool/docs'
make: *** [Makefile:16: docs] Error 2
```
