### PR TITLE
New PKGBUILD

### DIFF
--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -1,0 +1,30 @@
+# Maintainer: Your Name <youremail@domain.com>
+pkgname=dool
+pkgver=1.1.0
+pkgrel=1
+pkgdesc="Command to inspect the OS. Uses plug-ins."
+arch=(x86_64)
+url="https://github.com/scottchiefbaker/dool"
+license=('GPL2')
+groups=()
+depends=()
+# makedepends=(asciidoc xmlto)
+provides=("${pkgname%}")
+conflicts=("${pkgname%}")
+replaces=()
+backup=()
+options=()
+install=
+source=("https://github.com/scottchiefbaker/dool/archive/refs/tags/v1.1.0.tar.gz")
+noextract=()
+md5sums=('SKIP')
+
+build() {
+    cd "$pkgname-$pkgver"
+    make
+}
+
+package() {
+    cd "$pkgname-$pkgver"
+    make DESTDIR="$pkgdir/" install
+}


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature pull-request

##### DSTAT VERSION
```
$ dool --version
Dool 1.1.0
Written by Scott Baker <scott@perturb.org>
Forked from Dstat written by Dag Wieers <dag@wieers.com>
Homepage at https://github.com/scottchiefbaker/dool/

Platform posix/linux
Kernel 6.0.9-arch1-1
Python 3.10.8 (main, Nov  1 2022, 14:18:21) [GCC 12.2.0]

Terminal type: xterm-256color (color support)
Terminal size: 60 lines, 199 columns

Processors: 12
Pagesize: 4096
Clock ticks per secs: 100

internal:
	aio,cpu,cpu-adv,cpu-use,cpu24,disk,disk24,disk24-old,epoch,fs,int,int24,io,ipc,load,lock,mem,mem-adv,net,page,page24,proc,raw,socket,swap,swap-old,sys,tcp,time,
	udp,unix,vm,vm-adv,zones
/usr/share/dool:
	battery,battery-remain,condor-queue,cpufreq,dbus,disk-avgqu,disk-avgrq,disk-svctm,disk-tps,disk-util,disk-wait,dool,dool-cpu,dool-ctxt,dool-mem,fan,freespace,fuse,gpfs,
	gpfs-ops,helloworld,ib,innodb-buffer,innodb-io,innodb-ops,jvm-full,jvm-vm,lustre,md-status,memcache-hits,mongodb-conn,mongodb-mem,mongodb-opcount,mongodb-queue,mongodb-stats,
	mysql-io,mysql-keys,mysql5-cmds,mysql5-conn,mysql5-innodb,mysql5-innodb-basic,mysql5-innodb-extra,mysql5-io,mysql5-keys,net-packets,nfs3,nfs3-ops,nfsd3,nfsd3-ops,nfsd4-ops,
	nfsstat4,ntp,postfix,power,proc-count,qmail,redis,rpc,rpcd,sendmail,snmp-cpu,snmp-load,snmp-mem,snmp-net,snmp-net-err,snmp-sys,snooze,squid,test,thermal,top-bio,
	top-bio-adv,top-childwait,top-cpu,top-cpu-adv,top-cputime,top-cputime-avg,top-int,top-io,top-io-adv,top-latency,top-latency-avg,top-mem,top-oom,utmp,vm-cpu,vm-mem,
	vm-mem-adv,vmk-hba,vmk-int,vmk-nic,vz-cpu,vz-io,vz-ubc,wifi,zfs-arc,zfs-l2arc,zfs-zil
```

##### SUMMARY
Add PKGBUILD for Arch Linux build system.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

```
Before:
$ makepkg -si
==> ERROR: PKGBUILD does not exist.

After:
$ makepkg -si
==> Making package: dool 3.14-1 (Tue 22 Nov 2022 10:50:24 PM EST)
==> Checking runtime dependencies...
==> Checking buildtime dependencies...
==> Retrieving sources...
  -> Found v3.14.tar.gz
==> Validating source files with md5sums...
    v3.14.tar.gz ... Skipped
==> Extracting sources...
  -> Extracting v3.14.tar.gz with bsdtar
==> Removing existing $pkgdir/ directory...
==> Starting build()...
make -C docs docs
make[1]: Entering directory '/home/ambie/pkg/dool/src/dool-3.14/docs'
make[1]: Nothing to be done for 'docs'.
make[1]: Leaving directory '/home/ambie/pkg/dool/src/dool-3.14/docs'
Nothing to be build.
==> Entering fakeroot environment...
==> Starting package()...
install -Dp -m0755 dool /home/ambie/pkg/dool/pkg/dool//usr/bin/dool
install -d  -m0755 /home/ambie/pkg/dool/pkg/dool//usr/share/dool/
install -Dp -m0755 dool /home/ambie/pkg/dool/pkg/dool//usr/share/dool/dool.py
install -Dp -m0644 plugins/dool_*.py /home/ambie/pkg/dool/pkg/dool//usr/share/dool/
install -Dp -m0644 docs/dool.1 /home/ambie/pkg/dool/pkg/dool//usr/share/man/man1/dool.1
==> Tidying install...
  -> Removing libtool files...
  -> Purging unwanted files...
  -> Removing static library files...
  -> Stripping unneeded symbols from binaries and libraries...
  -> Compressing man and info pages...
==> Checking for packaging issues...
==> Creating package "dool"...
  -> Generating .PKGINFO file...
  -> Generating .BUILDINFO file...
  -> Generating .MTREE file...
  -> Compressing package...
==> Leaving fakeroot environment.
==> Finished making: dool 3.14-1 (Tue 22 Nov 2022 10:50:28 PM EST)
==> Installing package dool with pacman -U...
loading packages...
resolving dependencies...
looking for conflicting packages...

Packages (1) dool-3.14-1

Total Installed Size:  0.38 MiB

:: Proceed with installation? [Y/n] 
(1/1) checking keys in keyring                              [########################################################################] 100%
(1/1) checking package integrity                            [########################################################################] 100%
(1/1) loading package files                                 [########################################################################] 100%
(1/1) checking for file conflicts                           [########################################################################] 100%
(1/1) checking available disk space                         [########################################################################] 100%
:: Processing package changes...
(1/1) installing dool                                       [########################################################################] 100%
:: Running post-transaction hooks...
(1/2) Arming ConditionNeedsUpdate...
(2/2) Refreshing PackageKit...
```
