### PR TITLE
Fix rename in docs

### DIFF
--- a/docs/dool.1.adoc
+++ b/docs/dool.1.adoc
@@ -1,35 +1,35 @@
-= dstat(1)
+= dool(1)
 Dag Wieers <dag@wieers.com>
 v0.7.3, August 2014
 
 
 == NAME
-dstat - versatile tool for generating system resource statistics
+dool - versatile tool for generating system resource statistics
 
 
 == SYNOPSIS
-dstat [-afv] [options..] [delay [count]]
+dool [-afv] [options..] [delay [count]]
 
 
 == DESCRIPTION
-Dstat is a versatile replacement for vmstat, iostat and ifstat. Dstat
+Dool is a versatile replacement for vmstat, iostat and ifstat. Dool
 overcomes some of the limitations and adds some extra features.
 
-Dstat allows you to view all of your system resources instantly, you
+Dool allows you to view all of your system resources instantly, you
 can eg. compare disk usage in combination with interrupts from your
 IDE controller, or compare the network bandwidth numbers directly with
 the disk throughput (in the same interval).
 
-Dstat also cleverly gives you the most detailed information in columns
+Dool also cleverly gives you the most detailed information in columns
 and clearly indicates in what magnitude and unit the output is displayed.
 Less confusion, less mistakes, more efficient.
 
-Dstat is unique in letting you aggregate block device throughput for a
+Dool is unique in letting you aggregate block device throughput for a
 certain diskset or network bandwidth for a group of interfaces, ie. 
 you can see the throughput for all the block devices that make up a
 single filesystem or storage system.
 
-Dstat allows its data to be directly written to a CSV file to be
+Dool allows its data to be directly written to a CSV file to be
 imported and used by OpenOffice, Gnumeric or Excel to create graphs.
 
 [NOTE]
@@ -187,13 +187,13 @@ Possible internal stats are::
     write CSV output to file
 
 --profile::
-    show profiling statistics when exiting dstat
+    show profiling statistics when exiting dool
 
 
 == PLUGINS
-While anyone can create their own dstat plugins (and contribute them) dstat
+While anyone can create their own dool plugins (and contribute them) dool
 ships with a number of plugins already that extend its capabilities greatly.
-Here is an overview of the plugins dstat ships with:
+Here is an overview of the plugins dool ships with:
 
 --battery::
     battery in percentage (needs ACPI)
@@ -225,17 +225,17 @@ Here is an overview of the plugins dstat ships with:
 --disk-wait::
     average time (in milliseconds) for I/O requests issued to the device to be served
 
---dstat::
-    show dstat cputime consumption and latency
+--dool::
+    show dool cputime consumption and latency
 
---dstat-cpu::
-    show dstat advanced cpu usage
+--dool-cpu::
+    show dool advanced cpu usage
 
---dstat-ctxt::
-    show dstat context switches
+--dool-ctxt::
+    show dool context switches
 
---dstat-mem::
-    show dstat advanced memory usage
+--dool-mem::
+    show dool advanced memory usage
 
 --fan::
     fan speed (needs ACPI)
@@ -250,7 +250,7 @@ Here is an overview of the plugins dstat ships with:
     GPFS filesystem operations (needs mmpmon)
 
 --helloworld::
-    Hello world example dstat plugin
+    Hello world example dool plugin
 
 --innodb-buffer::
     show innodb buffer stats
@@ -340,22 +340,22 @@ Here is an overview of the plugins dstat ships with:
     show sendmail queue size (needs sendmail)
 
 --snmp-cpu::
-    show CPU stats using SNMP from DSTAT_SNMPSERVER
+    show CPU stats using SNMP from DOOL_SNMPSERVER
 
 --snmp-load::
-    show load stats using SNMP from DSTAT_SNMPSERVER
+    show load stats using SNMP from DOOL_SNMPSERVER
 
 --snmp-mem::
-    show memory stats using SNMP from DSTAT_SNMPSERVER
+    show memory stats using SNMP from DOOL_SNMPSERVER
 
 --snmp-net::
-    show network stats using SNMP from DSTAT_SNMPSERVER
+    show network stats using SNMP from DOOL_SNMPSERVER
 
 --snmp-net-err:
-    show network errors using SNMP from DSTAT_SNMPSERVER
+    show network errors using SNMP from DOOL_SNMPSERVER
 
 --snmp-sys::
-    show system stats (interrupts and context switches) using SNMP from DSTAT_SNMPSERVER
+    show system stats (interrupts and context switches) using SNMP from DOOL_SNMPSERVER
 
 --snooze::
     show number of ticks per second
@@ -463,7 +463,7 @@ The default delay is 1 and count is unspecified (unlimited)
 
 
 == INTERMEDIATE UPDATES
-When invoking dstat with a *delay* greater than 1 and without the
+When invoking dool with a *delay* greater than 1 and without the
 *--noupdate* option, it will show intermediate updates, ie. the first
 time a 1 sec average, the second update a 2 second average, etc. until
 the delay has been reached.
@@ -475,34 +475,34 @@ average on a new line, just like with vmstat.
 
 
 == EXAMPLES
-Using dstat to relate disk-throughput with network-usage (eth0), total CPU-usage and system counters:
+Using dool to relate disk-throughput with network-usage (eth0), total CPU-usage and system counters:
 ----
-dstat -dnyc -N eth0 -C total -f 5
+dool -dnyc -N eth0 -C total -f 5
 ----
 
-Checking dstat's behaviour and the system impact of dstat:
+Checking dool's behaviour and the system impact of dool:
 ----
-dstat -taf --debug
+dool -taf --debug
 ----
 
 Using the time plugin together with cpu, net, disk, system, load, proc and
 top_cpu plugins:
 ----
-dstat -tcndylp --top-cpu
+dool -tcndylp --top-cpu
 ----
 this is identical to
 ----
-dstat --time --cpu --net --disk --sys --load --proc --top-cpu
+dool --time --cpu --net --disk --sys --load --proc --top-cpu
 ----
 
-Using dstat to relate advanced cpu stats with interrupts per device:
+Using dool to relate advanced cpu stats with interrupts per device:
 ----
-dstat -t --cpu-adv -yif
+dool -t --cpu-adv -yif
 ----
 
 
 == BUGS
-Since it is practically impossible to test dstat on every possible
+Since it is practically impossible to test dool on every possible
 permutation of kernel, python or distribution version, I need your
 help and your feedback to fix the remaining problems. If you have
 improvements or bugreports, please send them to:
@@ -513,40 +513,40 @@ Please see the TODO file for known bugs and future plans.
 
 
 == FILES
-Paths that may contain external dstat_*.py plugins:
+Paths that may contain external dool_*.py plugins:
 
-    ~/.dstat/
+    ~/.dool/
     (path of binary)/plugins/
-    /usr/share/dstat/
-    /usr/local/share/dstat/
+    /usr/share/dool/
+    /usr/local/share/dool/
 
 == ENVIRONMENT VARIABLES
 
-Dstat will read additional command line arguments from the environment
-variable *DSTAT_OPTS*. You can use this to configure Dstat's default
+Dool will read additional command line arguments from the environment
+variable *DOOL_OPTS*. You can use this to configure Dool's default
 behavior, e.g. if you have a black-on-white terminal:
 
-    export DSTAT_OPTS="--bw --noupdate"
+    export DOOL_OPTS="--bw --noupdate"
 
 Other internal or external plugins have their own environment variables
 to influence their behavior, e.g.
 
 
-    DSTAT_NTPSERVER
+    DOOL_NTPSERVER
 
-    DSTAT_MYSQL
-    DSTAT_MYSQL_HOST
-    DSTAT_MYSQL_PORT
-    DSTAT_MYSQL_SOCKET
-    DSTAT_MYSQL_USER
-    DSTAT_MYSQL_PWD
+    DOOL_MYSQL
+    DOOL_MYSQL_HOST
+    DOOL_MYSQL_PORT
+    DOOL_MYSQL_SOCKET
+    DOOL_MYSQL_USER
+    DOOL_MYSQL_PWD
 
-    DSTAT_SNMPSERVER
-    DSTAT_SNMPCOMMUNITY
+    DOOL_SNMPSERVER
+    DOOL_SNMPCOMMUNITY
 
-    DSTAT_SQUID_OPTS
+    DOOL_SQUID_OPTS
 
-    DSTAT_TIMEFMT
+    DOOL_TIMEFMT
 
 == SEE ALSO
 


### PR DESCRIPTION
The content of dool.1.adoc is completly unchanged from dstat.1.adoc. Unfortunately the 'NAME' specifies the created file name. So building/cleaning docs is currently broken

##### ISSUE TYPE
 - Docs pull-request

##### DSTAT VERSION
```
Dool 1.1.0
Written by Scott Baker <scott@perturb.org>
Forked from Dstat written by Dag Wieers <dag@wieers.com>
Homepage at https://github.com/scottchiefbaker/dool/

Platform posix/linux
Kernel 5.15.0-56-generic
Python 3.10.6 (main, Nov  2 2022, 18:53:38) [GCC 11.3.0]

Terminal type: xterm-256color (color support)
Terminal size: 30 lines, 211 columns

Processors: 12
Pagesize: 4096
Clock ticks per secs: 100

internal:
        aio,cpu,cpu-adv,cpu-use,cpu24,disk,disk24,disk24-old,epoch,fs,int,int24,io,ipc,load,lock,mem,mem-adv,net,page,page24,proc,raw,socket,swap,swap-old,sys,tcp,time,udp,unix,
        vm,vm-adv,zones
/home/steina/repo/dool/plugins:
        battery,battery-remain,condor-queue,cpufreq,dbus,disk-avgqu,disk-avgrq,disk-svctm,disk-tps,disk-util,disk-wait,dool,dool-cpu,dool-ctxt,dool-mem,fan,freespace,fuse,gpfs,gpfs-ops,
        helloworld,ib,innodb-buffer,innodb-io,innodb-ops,jvm-full,jvm-vm,lustre,md-status,memcache-hits,mongodb-conn,mongodb-mem,mongodb-opcount,mongodb-queue,mongodb-stats,mysql-io,mysql-keys,
        mysql5-cmds,mysql5-conn,mysql5-innodb,mysql5-innodb-basic,mysql5-innodb-extra,mysql5-io,mysql5-keys,net-packets,nfs3,nfs3-ops,nfsd3,nfsd3-ops,nfsd4-ops,nfsstat4,ntp,postfix,power,
        proc-count,qmail,redis,rpc,rpcd,sendmail,snmp-cpu,snmp-load,snmp-mem,snmp-net,snmp-net-err,snmp-sys,snooze,squid,test,thermal,top-bio,top-bio-adv,top-childwait,top-cpu,top-cpu-adv,
        top-cputime,top-cputime-avg,top-int,top-io,top-io-adv,top-latency,top-latency-avg,top-mem,top-oom,utmp,vm-cpu,vm-mem,vm-mem-adv,vmk-hba,vmk-int,vmk-nic,vz-cpu,vz-io,vz-ubc,wifi,
        zfs-arc,zfs-l2arc,zfs-zil
```

##### SUMMARY
The (generated) man page `dool.1` has been modified manually, while ignoering the actual source file `dool.1.adoc`.

This PR renames remaining `dstat` names to `dool`, which fixes also the name of the generated man page file, which depends on the `NAME` tag.

This is essentially a follow-up to #28, allowing build systems do clean and generate docs at least