### PR TITLE
Remove underline from sequence separators

### DIFF
--- a/dool
+++ b/dool
@@ -580,7 +580,7 @@ class dstat:
 
             if isinstance(self.val[name], Sequence) and not isinstance(self.val[name], string_types):
                 line = line + cprintlist(self.val[name], ctype, self.width, scale)
-                sep  = theme['subtitle'] + char['colon'] + ansi['reset']
+                sep  = theme['subframe'] + char['colon'] + ansi['reset']
 
                 if i + 1 != len(self.vars):
                     line = line + sep
@@ -1893,6 +1893,7 @@ def set_theme():
             'title'     : color['darkblue'],
             'subtitle'  : color['darkcyan'] + ansi['underline'],
             'frame'     : color['darkblue'],
+            'subframe'  : color['darkcyan'],
             'default'   : ansi['default'],
             'error'     : color['white'] + color['redbg'],
             'roundtrip' : color['darkblue'],
@@ -1914,6 +1915,7 @@ def set_theme():
             'title'     : color['darkblue'],
             'subtitle'  : color['blue'] + ansi['underline'],
             'frame'     : color['darkblue'],
+            'subframe'  : color['blue'],
             'default'   : ansi['default'],
             'error'     : color['white'] + color['redbg'],
             'roundtrip' : color['darkblue'],


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature pull-request

##### DSTAT VERSION
```
$ dool --version
Dool 1.1.0
Written by Scott Baker <scott@perturb.org>
Forked from Dstat written by Dag Wieers <dag@wieers.com>
Homepage at https://github.com/scottchiefbaker/dool/

Platform posix/linux
Kernel 5.15.0-57-generic
Python 3.8.10 (default, Nov 14 2022, 12:59:47) 
[GCC 9.4.0]

Terminal type: xterm-256color (color support)
Terminal size: 39 lines, 175 columns

Processors: 24
Pagesize: 4096
Clock ticks per secs: 100

internal:
	aio,cpu,cpu-adv,cpu-use,cpu24,disk,disk24,disk24-old,epoch,fs,int,int24,io,ipc,load,lock,mem,mem-adv,net,page,page24,proc,raw,socket,swap,
	swap-old,sys,tcp,time,udp,unix,vm,vm-adv,zones
/home/maddoxw/git/dool2/plugins:
	battery,battery-remain,condor-queue,cpufreq,dbus,disk-avgqu,disk-avgrq,disk-svctm,disk-tps,disk-util,disk-wait,dool,dool-cpu,dool-ctxt,dool-mem,fan,
	freespace,fuse,gpfs,gpfs-ops,helloworld,ib,innodb-buffer,innodb-io,innodb-ops,jvm-full,jvm-vm,lustre,md-status,memcache-hits,mongodb-conn,mongodb-mem,
	mongodb-opcount,mongodb-queue,mongodb-stats,mysql-io,mysql-keys,mysql5-cmds,mysql5-conn,mysql5-innodb,mysql5-innodb-basic,mysql5-innodb-extra,mysql5-io,
	mysql5-keys,net-packets,nfs3,nfs3-ops,nfsd3,nfsd3-ops,nfsd4-ops,nfsstat4,ntp,postfix,power,proc-count,qmail,redis,rpc,rpcd,sendmail,snmp-cpu,
	snmp-load,snmp-mem,snmp-net,snmp-net-err,snmp-sys,snooze,squid,test,thermal,top-bio,top-bio-adv,top-childwait,top-cpu,top-cpu-adv,top-cputime,
	top-cputime-avg,top-int,top-io,top-io-adv,top-latency,top-latency-avg,top-mem,top-oom,utmp,vm-cpu,vm-mem,vm-mem-adv,vmk-hba,vmk-int,vmk-nic,vz-cpu,
	vz-io,vz-ubc,wifi,zfs-arc,zfs-l2arc,zfs-zil
```

##### SUMMARY
<!--- Describe the change here, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Command...
```
$ dool -tcmsnd -D sda,sdb,sdc,sdd,sde,sdf,nvme0n1 10
```

Before...

![Screenshot from 2023-01-11 06-48-20](https://user-images.githubusercontent.com/10588718/211810535-ed23db50-94b8-4e75-a38e-e9e154713683.png)


After...

![Screenshot from 2023-01-11 06-49-57](https://user-images.githubusercontent.com/10588718/211810684-dbfd8157-59a9-4747-af6e-c6c17d26798b.png)
