### PR TITLE
Revert commit b19d276 but keep the last 'K' for kibibyte uppercased

### DIFF
--- a/dool
+++ b/dool
@@ -2204,9 +2204,9 @@ def cprint(var, ctype = 'f', width = 4, scale = 1000):
             return theme['error'] + '-'.rjust(width) + theme['default']
 
     if base != 1024:
-        units = (char['space'], 'K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y')
+        units = (char['space'], 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y')
     elif op.bits and ctype in ('b', ):
-        units = ('B', 'K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y')
+        units = ('b', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y')
         base = scale = 1000
         var = var * 8.0
     else:

--- a/dool
+++ b/dool
@@ -2204,12 +2204,15 @@ def cprint(var, ctype = 'f', width = 4, scale = 1000):
             return theme['error'] + '-'.rjust(width) + theme['default']
 
     if base != 1024:
+        # Miscellaneous value using base of 1000 (1, kilo-, mega-, giga-, ...)
         units = (char['space'], 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y')
     elif op.bits and ctype in ('b', ):
+        # Bit value using base of 1000 (bit, kilobit, megabit, gigabit, ...)
         units = ('b', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y')
         base = scale = 1000
         var = var * 8.0
     else:
+        # Byte value using base of 1024 (byte, kibibyte, mebibyte, gibibyte, ...)
         units = ('B', 'K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y')
 
     if step == op.delay:


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix pull-request

##### DSTAT VERSION
Commit b19d276

##### SUMMARY
From message of last commit:

    Not sure why "k" and "b" were lowercase while ALL of the others
    were uppercase

The first and second `k` indicates 'kilo-' from SI, means `*1000`; it have to be lowercased according to it.

The first `b` is unit 'bit'; we usually writing it in lowercase, to distinguish it from unit 'byte', which is usually writing as `B`.

The third `k` -> `K` indicates 'kibi-', means `*1024`; and in this context, the complete unit is kibibyte (`KiB`), so the uppercase `K` is simply a compact abbreviation to `KiB`.

Of course those compact formats will never be fully complying with SI, due to screen space restriction; but it should be at least be close to it, as well as be consistent with other command line tools.