### PR TITLE
Add an option for `--diskset` for #35

### DIFF
--- a/docs/dool.1
+++ b/docs/dool.1
@@ -67,9 +67,14 @@ enable disk stats (read, write), for more disk related stats look into the other
 plugins
 .RE
 .PP
-\-D total,hda
+\-D total,sda
 .RS 4
-include total and hda (when using \-d/\-\-disk)
+include total and sda (when using \-\-disk)
+.RE
+.PP
+\-\-diskset diskset_name:dev1,dev2,dev3,etc\&...
+.RS 4
+group several disks together and report aggregate stats (when using \-\-disk)
 .RE
 .PP
 \-g, \-\-page

--- a/docs/dool.1.adoc
+++ b/docs/dool.1.adoc
@@ -44,8 +44,11 @@ imported and used by OpenOffice, Gnumeric or Excel to create graphs.
     enable disk stats (read, write), for more disk related stats look
     into the other *--disk* plugins
 
--D total,hda::
-    include total and hda (when using -d/--disk)
+-D total,sda::
+    include total and sda (when using --disk)
+
+--diskset diskset_name:dev1,dev2,dev3,etc...::
+	group several disks together and report aggregate stats (when using --disk)
 
 -g, --page::
     enable page stats (page in, page out)

--- a/docs/dool.1.html
+++ b/docs/dool.1.html
@@ -803,11 +803,19 @@ imported and used by OpenOffice, Gnumeric or Excel to create graphs.</p></div>
 </p>
 </dd>
 <dt class="hdlist1">
--D total,hda
+-D total,sda
 </dt>
 <dd>
 <p>
-    include total and hda (when using -d/--disk)
+    include total and sda (when using --disk)
+</p>
+</dd>
+<dt class="hdlist1">
+--diskset diskset_name:dev1,dev2,dev3,etc&#8230;
+</dt>
+<dd>
+<p>
+        group several disks together and report aggregate stats (when using --disk)
 </p>
 </dd>
 <dt class="hdlist1">
@@ -2091,7 +2099,7 @@ DOOL_SNMPCOMMUNITY</code></pre>
 <div id="footer-text">
 Version 1.1.0<br />
 Last updated
- 2023-06-05 12:54:51 PDT
+ 2023-06-05 14:47:19 PDT
 </div>
 </div>
 </body>

--- a/dool
+++ b/dool
@@ -1491,6 +1491,8 @@ def signal_handler(signum, frame):
 
     # If we're outputting to the display
     if op.display:
+        # Print a couple of spaces to cover up the "^C" that gets printed
+        print("\b\b        ")
         # Reset the ANSI colors just in case
         print(ansi['reset']);
         sys.stdout.flush()

--- a/dool
+++ b/dool
@@ -60,7 +60,8 @@ class Options:
         self.cpulist      = None
         self.debug        = 0
         self.delay        = 1
-        self.disklist     = None
+        self.disklist     = []
+        self.diskset      = {}
         self.full         = False
         self.float        = False
         self.integer      = False
@@ -87,19 +88,12 @@ class Options:
             self.header = False
             self.update = False
 
-        ### Temporary hardcoded for my own project
-        self.diskset = {
-            'local': ('sda', 'hd[a-d]'),
-            'lores': ('sd[b-k]', 'sd[v-z]', 'sda[a-e]'),
-            'hires': ('sd[l-u]', 'sda[f-o]'),
-        }
-
         try:
             opts, args = getopt.getopt(args, 'acdfghilmno:prstTvyC:D:I:M:N:S:V',
                 ['all', 'all-plugins', 'bits', 'bw', 'bytes', 'black-on-white', 'color',
                  'defaults', 'debug', 'filesystem', 'float', 'full', 'help', 'integer',
                  'list', 'mods', 'modules', 'more', 'nocolor', 'noheaders', 'noupdate',
-                 'output=', 'pidfile=', 'profile', 'version', 'vmstat', 'ascii', 'display'] + allplugins)
+                 'output=', 'pidfile=', 'profile', 'version', 'vmstat', 'ascii', 'display', 'diskset='] + allplugins)
         except getopt.error as exc:
             print('dool: %s, try dool -h for a list of all the options' % exc)
             sys.exit(1)
@@ -125,6 +119,18 @@ class Options:
                 self.plugins.append('disk')
             elif opt in ['-D']:
                 self.disklist = arg.split(',')
+            elif opt in ['--diskset']:
+                parts   = arg.split(":", 1)
+                name    = list_item_default(parts, 0, "Unknown")
+                members = list_item_default(parts, 1, "").split(", ")
+
+                if (len(parts) < 2 or len(members) < 1):
+                    print("Error parsing diskset...\n")
+                    print("Format : diskset_name:dev1,dev2,dev3,etc...")
+                    print("Example: --diskset os_drives:sda,sdb")
+
+                self.diskset[name] = members
+                self.disklist.append(name)
             elif opt in ['--filesystem']:
                 self.plugins.append('fs')
             elif opt in ['-g']:
@@ -222,6 +228,9 @@ class Options:
             else:
                 print('dool: option %s unknown to getopt, try dool -h for a list of all the options' % opt)
                 sys.exit(1)
+
+        #k(self.diskset)
+        #k(self.disklist)
 
         # If --display is before --output we have to reset it here
         if '--display' in opt_keys:
@@ -2627,6 +2636,13 @@ def perform(update):
         ### Finish the line
         if not op.update:
             sys.stdout.write('\n')
+
+# Get an item from a list, or a default value if the array isn't big enough
+def list_item_default(mylist, num, default):
+    if num > len(mylist) - 1:
+        return default
+    else:
+        return mylist[num]
 
 # Borrowed from: https://stackoverflow.com/questions/14693701/how-can-i-remove-the-ansi-escape-sequences-from-a-string-in-python
 def stripcolor(self, mystr):

--- a/dool
+++ b/dool
@@ -304,6 +304,7 @@ Dool options:
      -C 0,3,total             include cpu0, cpu3 and total
   -d, --disk               enable disk stats
      -D total,hda             include hda and total
+     --diskset name:sda,sdb   group disks together for aggregate stats
   -g, --page               enable page stats
   -i, --int                enable interrupt stats
      -I 5,eth2                include int5 and interrupt used by eth2

--- a/plugins/dool_bond.py
+++ b/plugins/dool_bond.py
@@ -1,0 +1,76 @@
+### Author: Ming-Hung Chen <minghung.chen@gmail.com>
+
+
+class dstat_plugin(dstat):
+    bonddirname = '/proc/net/bonding/'
+    netdirname = '/sys/class/net/'
+    """
+    Bytes received or sent through bonding interfaces.
+    Usage:
+        dool --bond -N <adapter name>,total
+        default dool --bond is the same as
+        dool --bond -N total
+
+    """
+
+    def __init__(self):
+        self.nick = ('recv', 'send')
+        self.type = 'd'
+        self.cols = 2
+        self.width = 6
+
+    def discover(self, *objlist):
+        ret = []
+        for subdirname in os.listdir(self.bonddirname):
+            if not os.path.isdir(os.path.join(self.netdirname,subdirname, 'statistics')) : continue
+            device_dir =  os.path.join(self.netdirname, subdirname, 'statistics')
+            ret.append(subdirname)
+        ret.sort()
+        for item in objlist: ret.append(item)
+        return ret
+
+    def vars(self):
+        ret = []
+        if op.netlist:
+            varlist = op.netlist
+        elif not op.full:
+            varlist = ('total',)
+        else:
+            varlist = self.discover
+            varlist.sort()
+        for name in varlist:
+            if name in self.discover + ['total']:
+                ret.append(name)
+        if not ret:
+            raise Exception('No suitable network interfaces found to monitor')
+        return ret
+
+    def name(self):
+        return ['bond/'+name for name in self.vars]
+
+    def extract(self):
+        self.set2['total'] = [0, 0]
+        ifaces = self.discover
+        for name in self.vars: self.set2[name] = [0, 0]
+        for name in ifaces:
+            rcv_counter_name=os.path.join(self.netdirname, name, 'statistics/rx_bytes')
+            xmit_counter_name=os.path.join(self.netdirname, name, 'statistics/tx_bytes')
+            rcv_lines = dopen(rcv_counter_name).readlines()
+            xmit_lines = dopen(xmit_counter_name).readlines()
+            if len(rcv_lines) < 1 or len(xmit_lines) < 1:
+                continue
+            rcv_value = int(rcv_lines[0])
+            xmit_value = int(xmit_lines[0])
+            if name in self.vars :
+                self.set2[name] = (rcv_value, xmit_value)
+            self.set2['total'] = ( self.set2['total'][0] + rcv_value, self.set2['total'][1] + xmit_value)
+        if update:
+            for name in self.set2:
+                self.val[name] = [
+                    (self.set2[name][0] - self.set1[name][0]) / elapsed,
+                    (self.set2[name][1] - self.set1[name][1]) / elapsed,                    
+                ]
+                if self.val[name][0] < 0: self.val[name][0] += maxint + 1
+                if self.val[name][1] < 0: self.val[name][1] += maxint + 1
+        if step == op.delay:
+            self.set1.update(self.set2)


### PR DESCRIPTION
This adds the `--diskset` option to the CLI params. It is invoked in the following manner:

```
dool --diskset os:vda --diskset vault:vdb,vdc
```

The format is as follows: `--diskset diskset_name:dev1,dev2,dev3,etc`, and can be repeated for multiple groupings. There are only seven characters available in the header for diskset, so long names will be truncated.

**Note:** documentation pending review and comment from other contributors. 