### PR TITLE
add support for terminals with only 16 colors

### DIFF
--- a/dool
+++ b/dool
@@ -90,7 +90,7 @@ class Options:
 
         try:
             opts, args = getopt.getopt(args, 'acdfghilmno:prstTvyC:D:I:M:N:S:V',
-                ['all', 'all-plugins', 'bits', 'bw', 'bytes', 'black-on-white', 'color',
+                ['all', 'all-plugins', 'bits', 'bw', 'bytes', 'black-on-white', 'color', 'color16',
                  'defaults', 'debug', 'filesystem', 'float', 'full', 'help', 'integer',
                  'list', 'mods', 'modules', 'more', 'nocolor', 'noheaders', 'noupdate',
                  'output=', 'pidfile=', 'profile', 'version', 'vmstat', 'ascii', 'display', 'diskset='] + allplugins)
@@ -189,7 +189,10 @@ class Options:
             elif opt in ['--bw', '--black-on-white', '--blackonwhite']:
                 self.blackonwhite = True
             elif opt in ['--color']:
-                self.color = True
+                self.color = 256
+                self.update = True
+            elif opt in ['--color16']:
+                self.color = 16
                 self.update = True
             elif opt in ['--debug']:
                 self.debug = self.debug + 1
@@ -348,7 +351,8 @@ Dool options:
   --integer                force integer values on screen
 
   --bw, --black-on-white   change colors for white background terminal
-  --color                  force colors
+  --color                  force 256 colors
+  --color16                force 16 colors
   --nocolor                disable colors
   --noheaders              disable repetitive headers
   --noupdate               disable intermediate updates
@@ -1558,6 +1562,35 @@ color = {
      'whitebg'  : '\033[47m',
 }
 
+color16 = {
+    'black': '\033[0;30m',
+    'darkred': '\033[0;31m',
+    'darkgreen': '\033[0;32m',
+    'darkyellow': '\033[0;33m',
+    'darkblue': '\033[0;34m',
+    'darkmagenta': '\033[0;35m',
+    'darkcyan': '\033[0;36m',
+    'gray': '\033[0;37m',
+
+    'darkgray': '\033[1;30m',
+    'red': '\033[1;31m',
+    'green': '\033[1;32m',
+    'yellow': '\033[1;33m',
+    'blue': '\033[1;34m',
+    'magenta': '\033[1;35m',
+    'cyan': '\033[1;36m',
+    'white': '\033[1;37m',
+
+    'blackbg': '\033[40m',
+    'redbg': '\033[41m',
+    'greenbg': '\033[42m',
+    'yellowbg': '\033[43m',
+    'bluebg': '\033[44m',
+    'magentabg': '\033[45m',
+    'cyanbg': '\033[46m',
+    'whitebg': '\033[47m',
+}
+
 ansi = {
     'reset'    : '\033[0;0m',
     'bold'     : '\033[1m',
@@ -1603,6 +1636,10 @@ char_box_draw = {
 
 def set_theme():
     "Provide a set of colors to use"
+    global color
+    if op.color == 16:
+        color = color16
+        
     if op.blackonwhite:
         theme = {
             'title'     : color['darkblue'],
@@ -2088,7 +2125,8 @@ def gettermcolor():
         try:
             import curses
             curses.setupterm()
-            if curses.tigetnum('colors') < 0:
+            colors = curses.tigetnum('colors')
+            if colors < 0:
                 return False
         except ImportError:
             print('Color support is disabled as python-curses is not installed.', file=sys.stderr)
@@ -2096,7 +2134,9 @@ def gettermcolor():
         except:
             print('Color support is disabled as curses does not find terminal "%s".' % os.getenv('TERM'), file=sys.stderr)
             return False
-        return True
+        if colors == 256:
+            return colors
+        return 16
     return False
 
 ### We only want to filter out paths, not ksoftirqd/1


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature pull-request

##### DSTAT VERSION
master

##### SUMMARY

Add back support for 16 color terminals, with `--color16`. It is selected by default if the terminal doesn't report 256 colors.

Fixes #18.