### PR TITLE
Fix help of vmstat (as it includes sys instead of swap) - Fixes #54

### DIFF
--- a/dool
+++ b/dool
@@ -357,7 +357,7 @@ Dool options:
   --more                   equals -cdnmplt
   -a, --all                equals -cdngmyplt
   -f, --full               automatically expand -C, -D, -I, -N and -S lists
-  -v, --vmstat             equals -pmgdsc -D total
+  -v, --vmstat             equals -pmgdyc -D total
 
   --bits                   force bits for values expressed in bytes
   --bytes                  force bytes for output measurements


### PR DESCRIPTION
##### DOOL VERSION
Dool 1.3.0

##### SUMMARY
Fix help of vmstat, as vmstat equals -pmgdyc (-y/--sys) instead of -pmgdsc (-s/--swap).
See issue #54.