### PR TITLE
Fixes #60 - Multiple SWAP's breaks output

### DIFF
--- a/dool
+++ b/dool
@@ -1301,7 +1301,6 @@ class dool_socket(dool):
 
 class dool_swap(dool):
     def __init__(self):
-        self.name = 'swap'
         self.nick = ('used', 'free')
         self.type = 'd'
         self.open('/proc/swaps')


### PR DESCRIPTION
##### DOOL VERSION
<!--- Paste Dool version here -->
Dool 1.3.0

##### SUMMARY
<!--- Describe the change here, including rationale and design decisions -->

Removes the hardcoded `self.name = 'swap'` line from the `dool_swap` plugin.
This has the fixes the broken output and calls `def name(self)` correctly.

This *might* be a breaking change, since the name changes from `swap` to `swp/total`, when only using `--swap` without `--full` or a custom `-S`.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Before:
```
$ dool --epoch --swap -S /dev/sdb4,/dev/sda4,total --aio
┄┄epoch┄┄┄┬┄┄┄┄swap┄┄┄┬async
  epoch   │ used  free│ #aio
1699676083│   0    10G┊   0    10G┊   0    20G│ 576B
1699676084│   0    10G┊   0    10G┊   0    20G│ 576B

$ dool --epoch --swap --aio
┄┄epoch┄┄┄┬┄┄┄┄swap┄┄┄┬async
  epoch   │ used  free│ #aio
1699676029│   0    20G│ 576B
1699676030│   0    20G│ 576B
```

After:
```
$ dool --epoch --swap -S /dev/sdb4,/dev/sda4,total --aio
┄┄epoch┄┄┄┬┄┄swp/sdb4┄┄┄┄swp/sda4┄┄┄swp/total┄┬async
  epoch   │ used  free  used  free  used  free│ #aio
1699676353│   0    10G┊   0    10G┊   0    20G│ 576B
1699676354│   0    10G┊   0    10G┊   0    20G│ 576B

$ dool --epoch --swap --aio                             
┄┄epoch┄┄┄┬┄swp/total┄┬async
  epoch   │ used  free│ #aio
1699676376│   0    20G│ 576B
1699676377│   0    20G│ 576B
```