### PR TITLE
Added rudimentary debian packaging information.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,11 @@
 *.pyc
 /dist
+
+/debian/*
+!/debian/changelog
+!/debian/control
+!/debian/dirs
+!/debian/install
+!/debian/manpages
+!/debian/rules
+!/debian/copyright

--- a/Makefile
+++ b/Makefile
@@ -54,3 +54,6 @@ srpm: dist
 
 snap:
 	cd packaging/snap/; snapcraft
+
+deb:
+	dpkg-buildpackage -us -uc

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,0 +1,5 @@
+dool (1.3.3-1) unstable; urgency=low
+
+  * Initial packaging of the Python3 compatible fork of dstat.
+
+ -- Uroš Knupleš <uros@knuples.net>  Sun, 06 Oct 2024 11:18:38 +0200

--- a/debian/control
+++ b/debian/control
@@ -1,0 +1,16 @@
+Source: dool
+Section: utils
+Priority: optional
+Maintainer: Uroš Knupleš <uros@knuples.net> 
+Build-Depends: debhelper-compat (= 13)
+Homepage: https://github.com/scottchiefbaker/dool
+
+Package: dool
+Architecture: all
+Depends: ${misc:Depends}, python3
+Description: Python3 compatible fork of dstat.
+ Dool is a versatile replacement for vmstat, iostat, netstat and ifstat.
+ Dool overcomes some of their limitations and adds some extra features,
+ more counters and flexibility. Dool is handy for monitoring systems
+ during performance tuning tests, benchmarks or troubleshooting.
+

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,0 +1,7 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: dool
+Source: https://github.com/scottchiefbaker/dool
+
+Files: *
+Copyright: 2024 Scott Baker <scott@perturb.org>
+License: GPL-3.0+

--- a/debian/dirs
+++ b/debian/dirs
@@ -1,0 +1,3 @@
+usr/bin
+usr/share/dool
+usr/share/man/man1

--- a/debian/install
+++ b/debian/install
@@ -1,0 +1,3 @@
+dool usr/bin
+plugins/* usr/share/dool/
+docs/dool.1 usr/share/man/man1/

--- a/debian/manpages
+++ b/debian/manpages
@@ -1,0 +1,1 @@
+docs/dool.1

--- a/debian/rules
+++ b/debian/rules
@@ -1,0 +1,17 @@
+#!/usr/bin/make -f
+
+%:
+	dh $@
+
+override_dh_auto_install:
+	dh_install
+	dh_installman
+
+override_dh_auto_test:
+	# Disable the test suite
+
+override_dh_auto_clean:	
+	# Don't clean stuff
+
+override_dh_auto_build:
+	# No build step needed

--- a/docs/dool.1
+++ b/docs/dool.1
@@ -2,12 +2,12 @@
 .\"     Title: dool
 .\"    Author: Scott Baker <scott@perturb.org>
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: June 2023
+.\"      Date: October 2024
 .\"    Manual: \ \&
-.\"    Source: \ \& 1.1.0
+.\"    Source: \ \& 1.3.0
 .\"  Language: English
 .\"
-.TH "DOOL" "1" "June 2023" "\ \& 1\&.1\&.0" "\ \&"
+.TH "DOOL" "1" "October 2024" "\ \& 1\&.3\&.0" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/docs/dool.1.adoc
+++ b/docs/dool.1.adoc
@@ -1,6 +1,6 @@
 = dool(1)
 Scott Baker <scott@perturb.org>
-v1.1.0, June 2023
+v1.3.0, October 2024
 
 == NAME
 dool - versatile tool for generating system resource statistics

--- a/docs/dool.1.html
+++ b/docs/dool.1.html
@@ -4,7 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
 <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
-<meta name="generator" content="AsciiDoc 9.1.0" />
+<meta name="generator" content="AsciiDoc 10.2.1" />
 <title>dool(1)</title>
 <style type="text/css">
 /* Shared CSS for AsciiDoc xhtml11 and html5 backends */
@@ -2121,9 +2121,9 @@ DOOL_SNMPCOMMUNITY</code></pre>
 <div id="footnotes"><hr /></div>
 <div id="footer">
 <div id="footer-text">
-Version 1.1.0<br />
+Version 1.3.0<br />
 Last updated
- 2024-05-08 13:38:10 PDT
+ 2024-10-06 09:55:05 UTC
 </div>
 </div>
 </body>


### PR DESCRIPTION
This should allow anyone to build a basic installable .deb package out of checkout of this repository.

I introduced basic Debian packaging files to the repository, providing an initial setup that allowed me to build a simple installable .deb package directly from a checkout - meant for environments where .deb packages are preferred (e.g. Debian, Ubuntu).

Tests during packaging are skipped, as I've noticed `--all-plugins` test fails completely on my machine.