### PR TITLE
Fix plugin loading for Python 3.13

### DIFF
--- a/dool
+++ b/dool
@@ -2735,8 +2735,9 @@ def main():
 
         try:
             if pluginfile not in globals():
-                exec(open(pluginfile).read())
-                exec('global plug; plug = dool_plugin(); del(dool_plugin)')
+                scope = {}
+                exec(open(pluginfile).read(), globals(), scope)
+                exec('global plug; plug = dool_plugin(); del(dool_plugin)', globals(), scope)
                 plug.filename = pluginfile
                 plug.check()
                 plug.prepare()

--- a/dool
+++ b/dool
@@ -2737,12 +2737,12 @@ def main():
             if pluginfile not in globals():
                 scope = {}
                 exec(open(pluginfile).read(), globals(), scope)
-                exec('global plug; plug = dool_plugin(); del(dool_plugin)', globals(), scope)
+                plug = scope['dool_plugin']()
                 plug.filename = pluginfile
                 plug.check()
                 plug.prepare()
             else:
-                exec('global plug; plug = %s()' % pluginfile)
+                plug = globals()[pluginfile]()
                 plug.check()
                 plug.prepare()
 


### PR DESCRIPTION
##### DOOL VERSION
<!--- Paste Dool version here -->
Dool 1.3.2

Python 3.13.1 (main, Dec  4 2024, 18:05:56) [GCC 14.2.1 20240910]

Arch Linux

##### SUMMARY
<!--- Describe the change here, including rationale and design decisions -->
Python 3.13 changes how the `exec` builtin works. See https://github.com/python/cpython/issues/118888

Tl;dr: things defined in the `exec` context no longer show up in the caller's local scope; you have to explicitly pass a dict you want to be modified instead.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Before:
```
% dool --thermal
Traceback (most recent call last):
  File "/usr/bin/dool", line 2716, in main
    exec('global plug; plug = dool_plugin(); del(dool_plugin)')
    ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<string>", line 1, in <module>
NameError: name 'dool_plugin' is not defined. Did you mean: 'show_plugins'?

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/bin/dool", line 3057, in <module>
    __main()
    ~~~~~~^^
  File "/usr/bin/dool", line 3045, in __main
    main()
    ~~~~^^
  File "/usr/bin/dool", line 2726, in main
    if mod == mods[-1]:
       ^^^
NameError: name 'mod' is not defined
```

After:
```
% dool --thermal
the
tz0
 30
 30
 30
...
```