### PR TITLE
fix undefined variable 'mod' in plugin loading error reporting

### DIFF
--- a/dool
+++ b/dool
@@ -2746,7 +2746,7 @@ def main():
                 plug.prepare()
 
         except Exception as e:
-            if mod == mods[-1]:
+            if plugin == op.plugins[-1]:
                 print('Module %s failed to load. (%s)' % (pluginfile, e), file=sys.stderr)
             elif op.debug:
                 print('Module %s failed to load, trying another. (%s)' % (pluginfile, e), file=sys.stderr)


### PR DESCRIPTION
##### DOOL VERSION
<!--- Paste Dool version here -->
Dool 1.3.2

##### SUMMARY
<!--- Describe the change here, including rationale and design decisions -->
(split off from #83)

The plugin loading error-printing code, currently references a `mod` and `mods` variables which are never defined. Errors in loading plugins result in printing the error as an exception, followed by a confusing extra exception about the undefined variables.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Example using the nfs3 plugin on my machine which doesn't have NFS 3:

before:
```
% ./dool --nfs3
Traceback (most recent call last):
  File "/home/wfraser/src/ext/dool/./dool", line 2740, in main
    plug = scope['dool_plugin']()
  File "<string>", line 11, in __init__
  File "/home/wfraser/src/ext/dool/./dool", line 545, in open
    raise Exception('Cannot open file %s' % filename)
Exception: Cannot open file /proc/net/rpc/nfs

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/wfraser/src/ext/dool/./dool", line 3088, in <module>
    __main()
    ~~~~~~^^
  File "/home/wfraser/src/ext/dool/./dool", line 3076, in __main
    main()
    ~~~~^^
  File "/home/wfraser/src/ext/dool/./dool", line 2750, in main
    if mod == mods[-1]:
       ^^^
NameError: name 'mod' is not defined
```

After
```
% ./dool --nfs3
Module /usr/share/dool/dool_nfs3.py failed to load. (Cannot open file /proc/net/rpc/nfs)
None of the stats you selected are available.
```