### PR TITLE
Add plugin for LNET (Lustre Network)

### DIFF
--- a/docs/dool.1
+++ b/docs/dool.1
@@ -454,6 +454,11 @@ show innodb operations counters
 show lustre I/O throughput
 .RE
 .PP
+\-\-lnet
+.RS 4
+show lustre network I/O stats
+.RE
+.PP
 \-\-md\-status
 .RS 4
 show software raid (md) progress and speed

--- a/docs/dool.1.adoc
+++ b/docs/dool.1.adoc
@@ -279,6 +279,9 @@ Here is an overview of the plugins dool ships with:
 --lustre::
     show lustre I/O throughput
 
+--lnet::
+    show lustre network I/O stats
+
 --md-status::
     show software raid (md) progress and speed
 

--- a/docs/dool.1.html
+++ b/docs/dool.1.html
@@ -4,7 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
 <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
-<meta name="generator" content="AsciiDoc 9.1.0" />
+<meta name="generator" content="AsciiDoc 10.2.1" />
 <title>dool(1)</title>
 <style type="text/css">
 /* Shared CSS for AsciiDoc xhtml11 and html5 backends */
@@ -1417,6 +1417,14 @@ Here is an overview of the plugins dool ships with:</p></div>
 </p>
 </dd>
 <dt class="hdlist1">
+--lnet
+</dt>
+<dd>
+<p>
+    show lustre network I/O stats
+</p>
+</dd>
+<dt class="hdlist1">
 --md-status
 </dt>
 <dd>
@@ -2123,7 +2131,7 @@ DOOL_SNMPCOMMUNITY</code></pre>
 <div id="footer-text">
 Version 1.3.0<br />
 Last updated
- 2024-10-07 14:12:47 PDT
+ 2025-02-06 12:09:38 CET
 </div>
 </div>
 </body>

--- a/plugins/dool_lnet.py
+++ b/plugins/dool_lnet.py
@@ -1,5 +1,14 @@
 # Author: Hans-Nikolai Viessmann <hans-nikolai.viessmann@psi.ch>
 
+# Lustre network utilisation is tricky to capture, as the Lustre
+# driver and the Luster Network driver operate outside of the
+# kernel network stack, i.e. read/write IO on Lustre mount does
+# not report any network activity.
+#
+# Implemnetation is based on stats information collected via
+# LNET and _described_ in the source code, see:
+# https://github.com/lustre/lustre-release/blob/master/lnet/lnet/lnet_debugfs.c
+
 class dool_plugin(dool):
     def __init__(self):
         self.name = 'lnet'

--- a/plugins/dool_lnet.py
+++ b/plugins/dool_lnet.py
@@ -1,0 +1,29 @@
+# Author: Hans-Nikolai Viessmann <hans-nikolai.viessmann@psi.ch>
+
+class dool_plugin(dool):
+    def __init__(self):
+        self.name = 'lnet'
+        self.vars = ['recv', 'send']
+        self.type = 'b'
+        self.cols = 1
+        self.scale = 1000
+        self.open('/sys/kernel/debug/lnet/stats')
+
+    def check(self):
+        if not os.path.exists('/sys/kernel/debug/lnet/stats'):
+            raise Exception('LNET device not found')
+        info(1, 'Module %s is still experimental.' % self.filename)
+
+    def extract(self):
+        l = self.splitline()
+
+        self.set2['send'] = [int(l[7])]
+        self.set2['recv'] = [int(l[8])]
+
+        for name in self.vars:
+            self.val[name] = [(self.set2[name][0] - self.set1[name][0]) * 1.0 / elapsed]
+
+        if step == op.delay:
+            self.set1.update(self.set2)
+
+# vim:ts=4:sw=4

--- a/plugins/dool_lnet.py
+++ b/plugins/dool_lnet.py
@@ -5,7 +5,6 @@ class dool_plugin(dool):
         self.name = 'lnet'
         self.vars = ['recv', 'send']
         self.type = 'b'
-        self.cols = 1
         self.scale = 1000
         self.open('/sys/kernel/debug/lnet/stats')
 
@@ -17,11 +16,11 @@ class dool_plugin(dool):
     def extract(self):
         l = self.splitline()
 
-        self.set2['send'] = [int(l[7])]
-        self.set2['recv'] = [int(l[8])]
+        self.set2['send'] = int(l[7])
+        self.set2['recv'] = int(l[8])
 
         for name in self.vars:
-            self.val[name] = [(self.set2[name][0] - self.set1[name][0]) * 1.0 / elapsed]
+            self.val[name] = (self.set2[name] - self.set1[name]) * 1.0 / elapsed
 
         if step == op.delay:
             self.set1.update(self.set2)


### PR DESCRIPTION
##### DOOL VERSION
```
Dool 1.3.4
Written by Scott Baker <scott@perturb.org>
Forked from Dstat written by Dag Wieers <dag@wieers.com>
Homepage at https://github.com/scottchiefbaker/dool/

Platform posix/linux
Kernel 5.14.21-150500.55.65_13.0.73-cray_shasta_c
Python 3.6.15 (default, Sep 23 2021, 15:41:43) [GCC]

Terminal type: screen-256color (color support)
Terminal size: 67 lines, 384 columns

Processors: 128
Pagesize: 4096
Clock ticks per secs: 100

internal:
        aio,cpu,cpu-adv,cpu-use,disk,epoch,fs,int,io,ipc,load,lock,mem,mem-adv,net,page,proc,raw,socket,swap,sys,tcp,time,udp,unix,vm,vm-adv,zones
/root/.dool:
        battery,battery-remain,bond,condor-queue,cpufreq,dbus,disk-avgqu,disk-avgrq,disk-inflight,disk-svctm,disk-tps,disk-util,disk-wait,dool,dool-cpu,dool-ctxt,dool-mem,dool-step,fan,freespace,fuse,gpfs,gpfs-ops,helloworld,ib,innodb-buffer,innodb-io,innodb-ops,jvm-full,jvm-vm,lnet,lustre,md-status,mem-percent,memcache-hits,mongodb-conn,
        mongodb-mem,mongodb-opcount,mongodb-queue,mongodb-stats,mysql-io,mysql-keys,mysql5-cmds,mysql5-conn,mysql5-innodb,mysql5-innodb-basic,mysql5-innodb-extra,mysql5-io,mysql5-keys,net-packets,nfs3,nfs3-ops,nfsd3,nfsd3-ops,nfsd4-ops,nfsstat4,ntp,pid-detail,postfix,power,proc-count,qmail,redis,rpc,rpcd,sendmail,snmp-cpu,snmp-load,snmp-mem,
        snmp-net,snmp-net-err,snmp-sys,snooze,squid,test,thermal,top-bio,top-bio-adv,top-childwait,top-cpu,top-cpu-adv,top-cputime,top-cputime-avg,top-int,top-io,top-io-adv,top-latency,top-latency-avg,top-mem,top-oom,utmp,vm-cpu,vm-mem,vm-mem-adv,vmk-hba,vmk-int,vmk-nic,vz-cpu,vz-io,vz-ubc,wifi,zfs-arc,zfs-l2arc,zfs-zil
```

##### SUMMARY
I have added a plugin to view the recv/send IO over the Lustre network protocol (see [documentation](https://wiki.lustre.org/Lustre_Networking_(LNET)_Overview)). This, together with the existing `lustre` plugin, helps to more clearly view IO for Lustre client(s).

Below is an example where I wrote 1GB to the Lustre mount, via the `net` plugin (which gathers the stats from the physical network interfaces) we don't see any network behaviour relating to Lustre, but with the `lnet` plugin this now becomes visible.

```console
# dool --lustre --lnet --net
Module /root/.dool/dool_lustre.py is still experimental.
Module /root/.dool/dool_lnet.py is still experimental.
psistor-fff┬┄┄┄┄lnet┄┄┄┬┄net/total┄
 read write│ recv  send│ recv  send
40.4M 4589K│ 111M 4768k│   0     0 
   0     0 │   0     0 │ 310k  160k
   0     0 │   0     0 │ 180k  111k
   0     0 │   0     0 │ 233k  146k
   0  13.0B│   0     0 │ 180k   91k
   0     0 │   0     0 │ 307k  124k
   0   247M│  26k  243M│ 180k   90k
   0   292M│  33k  310M│ 178k   86k
   0   289M│  32k  302M│ 263k  131k
   0   172M│  26k  193M│ 181k  116k
   0     0 │   0     0 │ 180k   91k
   0     0 │   0     0 │ 301k  114k
   0     0 │   0     0 │ 178k   86k
```