### PR TITLE
Fix readpipe function and update plugins for Python3

### DIFF
--- a/dool
+++ b/dool
@@ -1894,7 +1894,7 @@ def readpipe(fileobj, tmout = 0.001):
     while not select.select([fileobj.fileno()], [], [], tmout)[0]:
         pass
     while select.select([fileobj.fileno()], [], [], tmout)[0]:
-        ret = ret + fileobj.read(1)
+        ret = ret + fileobj.read(1).decode("utf-8")
     return ret.split('\n')
 
 def greppipe(fileobj, str, tmout = 0.001):

--- a/plugins/dool_gpfs.py
+++ b/plugins/dool_gpfs.py
@@ -1,4 +1,4 @@
-### Author: Dag Wieers <dag$wieers,com>
+### Author: Dag Wieers <dag$wieers,com>, Ming-Hung Chen <minghung.chen@gmail.com>
 
 class dool_plugin(dool):
     """
@@ -14,7 +14,7 @@ class dool_plugin(dool):
         if os.access('/usr/lpp/mmfs/bin/mmpmon', os.X_OK):
             try:
                 self.stdin, self.stdout, self.stderr = dpopen('/usr/lpp/mmfs/bin/mmpmon -p -s')
-                self.stdin.write('reset\n')
+                self.stdin.write(b'reset\n')
                 readpipe(self.stdout)
             except IOError:
                 raise Exception('Cannot interface with gpfs mmpmon binary')
@@ -23,8 +23,7 @@ class dool_plugin(dool):
 
     def extract(self):
         try:
-            self.stdin.write('io_s\n')
-#           readpipe(self.stderr)
+            self.stdin.write(b'io_s\n')
             for line in readpipe(self.stdout):
                 if not line: continue
                 l = line.split()

--- a/plugins/dool_gpfs_ops.py
+++ b/plugins/dool_gpfs_ops.py
@@ -1,4 +1,4 @@
-### Author: Dag Wieers <dag$wieers,com>
+### Author: Dag Wieers <dag$wieers,com>, Ming-Hung Chen <minghung.chen@gmail.com>
 
 class dool_plugin(dool):
     """
@@ -17,7 +17,7 @@ class dool_plugin(dool):
         if os.access('/usr/lpp/mmfs/bin/mmpmon', os.X_OK):
             try:
                 self.stdin, self.stdout, self.stderr = dpopen('/usr/lpp/mmfs/bin/mmpmon -p -s')
-                self.stdin.write('reset\n')
+                self.stdin.write(b'reset\n')
                 readpipe(self.stdout)
             except IOError:
                 raise Exception('Cannot interface with gpfs mmpmon binary')
@@ -26,7 +26,7 @@ class dool_plugin(dool):
 
     def extract(self):
         try:
-            self.stdin.write('io_s\n')
+            self.stdin.write(b'io_s\n')
 #           readpipe(self.stderr)
             for line in readpipe(self.stdout):
                 if not line: continue

--- a/plugins/dool_innodb_buffer.py
+++ b/plugins/dool_innodb_buffer.py
@@ -1,4 +1,4 @@
-### Author: Dag Wieers <dag$wieers,com>
+### Author: Dag Wieers <dag$wieers,com>, Ming-Hung Chen <minghung.chen@gmail.com>
 
 global mysql_options
 mysql_options = os.getenv('DOOL_MYSQL')
@@ -22,7 +22,7 @@ class dool_plugin(dool):
 
     def extract(self):
         try:
-            self.stdin.write('show engine innodb status\G\n')
+            self.stdin.write(b'show engine innodb status\G\n')
             line = greppipe(self.stdout, 'Pages read ')
 
             if line:

--- a/plugins/dool_innodb_io.py
+++ b/plugins/dool_innodb_io.py
@@ -1,4 +1,4 @@
-### Author: Dag Wieers <dag$wieers,com>
+### Author: Dag Wieers <dag$wieers,com>, Ming-Hung Chen <minghung.chen@gmail.com>
 
 global mysql_options
 mysql_options = os.getenv('DOOL_MYSQL')
@@ -23,7 +23,7 @@ class dool_plugin(dool):
 
     def extract(self):
         try:
-            self.stdin.write('show engine innodb status\G\n')
+            self.stdin.write(b'show engine innodb status\G\n')
             line = matchpipe(self.stdout, '.*OS file reads,.*')
 
             if line:

--- a/plugins/dool_innodb_ops.py
+++ b/plugins/dool_innodb_ops.py
@@ -1,4 +1,4 @@
-### Author: Dag Wieers <dag$wieers,com>
+### Author: Dag Wieers <dag$wieers,com>, Ming-Hung Chen <minghung.chen@gmail.com>
 
 global mysql_options
 mysql_options = os.getenv('DOOL_MYSQL')
@@ -23,7 +23,7 @@ class dool_plugin(dool):
 
     def extract(self):
         try:
-            self.stdin.write('show engine innodb status\G\n')
+            self.stdin.write(b'show engine innodb status\G\n')
             line = greppipe(self.stdout, 'Number of rows inserted')
 
             if line:

--- a/plugins/dool_mysql5_innodb.py
+++ b/plugins/dool_mysql5_innodb.py
@@ -1,4 +1,4 @@
-### Author: HIROSE Masaaki <hirose31 _at_ gmail.com>
+### Author: HIROSE Masaaki <hirose31 _at_ gmail.com>, Ming-Hung Chen <minghung.chen@gmail.com>
 
 global mysql_options
 mysql_options = os.getenv('DSTAT_MYSQL') or ''
@@ -91,7 +91,7 @@ class dstat_plugin(dstat):
 
     def extract(self):
         try:
-            self.stdin.write('show global status;\n')
+            self.stdin.write(b'show global status;\n')
             for line in readpipe(self.stdout):
                 if line == '':
                     break

--- a/plugins/dool_mysql_io.py
+++ b/plugins/dool_mysql_io.py
@@ -1,3 +1,5 @@
+### Author: Dag Wieers <dag$wieers,com>, Ming-Hung Chen <minghung.chen@gmail.com>
+
 global mysql_options
 mysql_options = os.getenv('DOOL_MYSQL')
 
@@ -17,7 +19,7 @@ class dool_plugin(dool):
 
     def extract(self):
         try:
-            self.stdin.write("show status like 'Bytes_%';\n")
+            self.stdin.write(b"show status like 'Bytes_%';\n")
             for line in readpipe(self.stdout):
                 l = line.split()
                 if len(l) < 2: continue

--- a/plugins/dool_mysql_keys.py
+++ b/plugins/dool_mysql_keys.py
@@ -1,3 +1,5 @@
+### Author: Dag Wieers <dag$wieers,com>, Ming-Hung Chen <minghung.chen@gmail.com>
+
 global mysql_options
 mysql_options = os.getenv('DOOL_MYSQL')
 
@@ -20,7 +22,7 @@ class dool_plugin(dool):
 
     def extract(self):
         try:
-            self.stdin.write("show status like 'Key_%';\n")
+            self.stdin.write(b"show status like 'Key_%';\n")
             for line in readpipe(self.stdout):
                 l = line.split()
                 if len(l) < 2: continue


### PR DESCRIPTION
##### DOOL VERSION
<!--- Paste Dool version here -->
1.3

##### SUMMARY
<!--- Describe the change here, including rationale and design decisions -->

Fix the readpipe function, which requires an additional type conversion after the read OP in Python3
Update write OPs in the GPFS and DB plugins for Python3

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Before
```
$ ./dool --gpfs-ops
Module .../dool/plugins/dool_gpfs_ops.py failed to load. (a bytes-like object is required, not 'str')
```
After
```
$ ./dool --gpfs-ops
┄┄┄┄┄┄┄┄gpfs┄file┄operations┄┄┄┄┄┄┄
 open  clos  read  writ  rdir  inod
   0     0     0     0     0     0
```

##### Note

I only tested the two GPFS plugins but did not test the innodb/mysql DB plugins. 
However, the same error on write OP should occur if writing a str.
