### PR TITLE
Fix startup crash with --io-top and ignore duplicate plugin filenames

### DIFF
--- a/docs/dool.1
+++ b/docs/dool.1
@@ -864,12 +864,14 @@ Paths that may contain external dool_*\&.py plugins:
 .nf
 ~/\&.dool/
 (path of binary)/plugins/
-/usr/share/dool/
 /usr/local/share/dool/
+/usr/share/dool/
 .fi
 .if n \{\
 .RE
 .\}
+.sp
+Plugins found in earlier directories take precedence, plugins with the same filename in later directories are ignored\&.
 .SH "ENVIRONMENT VARIABLES"
 .sp
 Dool will read additional command line arguments from the environment variable \fBDOOL_OPTS\fR\&. You can use this to configure Dool\(cqs default behavior, e\&.g\&. if you have a black\-on\-white terminal:

--- a/docs/dool.1.adoc
+++ b/docs/dool.1.adoc
@@ -532,8 +532,11 @@ Paths that may contain external dool_*.py plugins:
 
     ~/.dool/
     (path of binary)/plugins/
-    /usr/share/dool/
     /usr/local/share/dool/
+    /usr/share/dool/
+
+Plugins found in earlier directories take precedence, plugins with the same
+filename in later directories are ignored.
 
 == ENVIRONMENT VARIABLES
 

--- a/docs/dool.1.html
+++ b/docs/dool.1.html
@@ -4,7 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
 <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
-<meta name="generator" content="AsciiDoc 9.1.0" />
+<meta name="generator" content="AsciiDoc 10.2.1" />
 <title>dool(1)</title>
 <style type="text/css">
 /* Shared CSS for AsciiDoc xhtml11 and html5 backends */
@@ -1993,9 +1993,11 @@ improvements or bugreports, please send them to:
 <div class="content">
 <pre><code>~/.dool/
 (path of binary)/plugins/
-/usr/share/dool/
-/usr/local/share/dool/</code></pre>
+/usr/local/share/dool/
+/usr/share/dool/</code></pre>
 </div></div>
+<div class="paragraph"><p>Plugins found in earlier directories take precedence, plugins with the same
+filename in later directories are ignored.</p></div>
 </div>
 </div>
 <div class="sect1">
@@ -2123,7 +2125,7 @@ DOOL_SNMPCOMMUNITY</code></pre>
 <div id="footer-text">
 Version 1.3.0<br />
 Last updated
- 2024-10-07 14:12:47 PDT
+ 2025-03-23 18:29:16 CET
 </div>
 </div>
 </body>

--- a/dool
+++ b/dool
@@ -49,8 +49,8 @@ theme = { 'default': '' }
 pluginpath = [
     os.path.expanduser('~/.dool/'),                           # home + /.dool/
     os.path.dirname(os.path.abspath(__file__)) + '/plugins/', # binary path + /plugins/
-    '/usr/share/dool/',
     '/usr/local/share/dool/',
+    '/usr/share/dool/',
 ]
 
 # Global variable to match drives in /proc/
@@ -2551,6 +2551,10 @@ def get_plugin_details():
         for filename in glob.glob(path + '/dool_*.py'):
             plugin_name = remod.match(filename).group(1)
             name        = plugin_name.replace('_', '-')
+
+            # Plugin was already loaded from another directory, ignore.
+            if name in ret:
+                continue
 
             ret[name] = filename
 

--- a/plugins/dool_top_io.py
+++ b/plugins/dool_top_io.py
@@ -26,9 +26,9 @@ class dool_plugin(dool):
             try:
                 ### Reset values
                 if pid not in self.pidset2:
-                    self.pidset2[pid] = {'read_bytes:': 0, 'write_bytes:': 0}
+                    self.pidset2[pid] = {'rchar:': 0, 'wchar:': 0}
                 if pid not in self.pidset1:
-                    self.pidset1[pid] = {'read_bytes:': 0, 'write_bytes:': 0}
+                    self.pidset1[pid] = {'rchar:': 0, 'wchar:': 0}
 
                 ### Extract name
                 name = proc_splitline('/proc/%s/stat' % pid)[1][1:-1]


### PR DESCRIPTION
##### DOOL VERSION
dool v1.3.4

##### SUMMARY
Fixes a regression from v1.3.3 where `dool --top-io` crashes on startup:
```
$ dool --top-io
Traceback (most recent call last):
  File "/usr/bin/dool", line 3088, in <module>
    __main()
    ~~~~~~^^
  File "/usr/bin/dool", line 3076, in __main
    main()
    ~~~~^^
  File "/usr/bin/dool", line 2784, in main
    scheduler.run()
    ~~~~~~~~~~~~~^^
  File "/usr/lib/python3.13/sched.py", line 151, in run
    action(*argument, **kwargs)
    ~~~~~~^^^^^^^^^^^^^^^^^^^^^
  File "/usr/bin/dool", line 2890, in perform
    o.extract()
    ~~~~~~~~~^^
  File "<string>", line 53, in extract
KeyError: 'rchar:'
```

While at it, I also ignored duplicate plugin filenames. That makes it possible to test this fix without having to remove the dool package installed through the package manager on Arch Linux.

In case you are wondering, the `dool --list` code does not have to be modified since it compares the file location of the loaded plugin against the directory from the `pluginpath` directory.