### PR TITLE
Include plugin path and source code in error tracebacks

### DIFF
--- a/dool
+++ b/dool
@@ -2797,7 +2797,8 @@ def main():
         try:
             if pluginfile not in globals():
                 scope = {}
-                exec(open(pluginfile).read(), globals(), scope)
+                code = compile(open(pluginfile).read(), pluginfile, 'exec')
+                exec(code, globals(), scope)
                 plug = scope['dool_plugin']()
                 plug.filename = pluginfile
                 plug.check()


### PR DESCRIPTION
##### DOOL VERSION
dool v1.3.4-36-g3d43a88 (with v1.3.4 globally installed in Arch Linux).

##### SUMMARY
When dool crashes due to an exception in a plugin, it is difficult to
find the offending plugin since `<string>` is shown as source file:

    $ ./dool --top-io
    ...
      File "/tmp/dool/./dool", line 2951, in perform
        o.extract()
        ~~~~~~~~~^^
      File "<string>", line 53, in extract
    KeyError: 'rchar:'

(This is #94 that is fixed in the next branch, but due to #98 the unfixed dool plugin is being loaded.)

After this change, the plugin filename and source code are included:

      File "/tmp/dool/./dool", line 2952, in perform
        o.extract()
        ~~~~~~~~~^^
      File "/usr/share/dool/dool_top_io.py", line 53, in extract
        read_usage  = (self.pidset2[pid]['rchar:'] - self.pidset1[pid]['rchar:']) * factor / elapsed
                       ~~~~~~~~~~~~~~~~~^^^^^^^^^^
    KeyError: 'rchar:'


