### PR TITLE
Fix multiple issues

### DIFF
--- a/dool
+++ b/dool
@@ -1904,7 +1904,7 @@ def greppipe(fileobj, str, tmout = 0.001):
     while not select.select([fileobj.fileno()], [], [], tmout)[0]:
         pass
     while select.select([fileobj.fileno()], [], [], tmout)[0]:
-        character = fileobj.read(1)
+        character = fileobj.read(1).decode("utf-8")
         if character != '\n':
             ret = ret + character
         elif ret.startswith(str):
@@ -1922,7 +1922,7 @@ def matchpipe(fileobj, string, tmout = 0.001):
     while not select.select([fileobj.fileno()], [], [], tmout)[0]:
         pass
     while select.select([fileobj.fileno()], [], [], tmout)[0]:
-        character = fileobj.read(1)
+        character = fileobj.read(1).decode("utf-8")
         if character != '\n':
             ret = ret + character
         elif regexp.match(ret):

--- a/dool
+++ b/dool
@@ -1889,6 +1889,14 @@ def dpopen(cmd):
 
     return pipes[cmd]
 
+def checkerrpipe(fileobj, search, tmout = 0.05):
+    """Check available data from pipe in a non-blocking fashion
+    and raise if it matches given search string"""
+    if select.select([fileobj.fileno()], [], [], tmout)[0]:
+        err = matchpipe(fileobj, search, tmout)
+        if err:
+            raise Exception(err)
+
 def readpipe(fileobj, tmout = 0.001):
     "Read available data from pipe in a non-blocking fashion"
     ret = ''

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -7,6 +7,7 @@ Homepage: https://github.com/scottchiefbaker/dool
 Package: dool
 Architecture: all
 Depends: python3
+Suggests: python3-mysqldb
 Version: <version>
 Description: Python3 compatible fork of dstat.
  Dool is a versatile replacement for vmstat, iostat, netstat and ifstat.

--- a/plugins/dool__pid_detail.py
+++ b/plugins/dool__pid_detail.py
@@ -65,7 +65,7 @@ class dool_plugin(dool):
 		line = line.strip()
 
 		# Find the proc name that's between the ( )
-		x     = re.search("\((.*?)\)", line)
+		x     = re.search(r"\((.*?)\)", line)
 		paren = x.group(1)
 
 		# Replace any spaces in the parens part with underscores

--- a/plugins/dool_innodb_buffer.py
+++ b/plugins/dool_innodb_buffer.py
@@ -1,7 +1,7 @@
 ### Author: Dag Wieers <dag$wieers,com>, Ming-Hung Chen <minghung.chen@gmail.com>
 
 global mysql_options
-mysql_options = os.getenv('DOOL_MYSQL')
+mysql_options = os.getenv('DOOL_MYSQL', '')
 
 class dool_plugin(dool):
     def __init__(self):

--- a/plugins/dool_innodb_buffer.py
+++ b/plugins/dool_innodb_buffer.py
@@ -17,6 +17,7 @@ class dool_plugin(dool):
             raise Exception('Needs MySQL binary')
         try:
             self.stdin, self.stdout, self.stderr = dpopen('/usr/bin/mysql -n %s' % mysql_options)
+            checkerrpipe(self.stderr, '.+')
         except IOError as e:
             raise Exception('Cannot interface with MySQL binary (%s)' % e)
 

--- a/plugins/dool_innodb_buffer.py
+++ b/plugins/dool_innodb_buffer.py
@@ -23,7 +23,7 @@ class dool_plugin(dool):
     def extract(self):
         try:
             self.stdin.write(b'show engine innodb status\\G\n')
-            line = greppipe(self.stdout, 'Pages read ')
+            line = matchpipe(self.stdout, r'^Pages read \d+')
 
             if line:
                 l = line.split()

--- a/plugins/dool_innodb_buffer.py
+++ b/plugins/dool_innodb_buffer.py
@@ -22,7 +22,7 @@ class dool_plugin(dool):
 
     def extract(self):
         try:
-            self.stdin.write(b'show engine innodb status\G\n')
+            self.stdin.write(b'show engine innodb status\\G\n')
             line = greppipe(self.stdout, 'Pages read ')
 
             if line:

--- a/plugins/dool_innodb_buffer.py
+++ b/plugins/dool_innodb_buffer.py
@@ -23,7 +23,7 @@ class dool_plugin(dool):
 
     def extract(self):
         try:
-            self.stdin.write(b'show engine innodb status\\G\n')
+            self.stdin.write(b'SHOW ENGINE INNODB STATUS\\G\n')
             line = matchpipe(self.stdout, r'^Pages read \d+')
 
             if line:

--- a/plugins/dool_innodb_io.py
+++ b/plugins/dool_innodb_io.py
@@ -24,7 +24,7 @@ class dool_plugin(dool):
 
     def extract(self):
         try:
-            self.stdin.write(b'show engine innodb status\\G\n')
+            self.stdin.write(b'SHOW ENGINE INNODB STATUS\\G\n')
             line = matchpipe(self.stdout, r'^\d+ OS file reads,')
 
             if line:

--- a/plugins/dool_innodb_io.py
+++ b/plugins/dool_innodb_io.py
@@ -1,7 +1,7 @@
 ### Author: Dag Wieers <dag$wieers,com>, Ming-Hung Chen <minghung.chen@gmail.com>
 
 global mysql_options
-mysql_options = os.getenv('DOOL_MYSQL')
+mysql_options = os.getenv('DOOL_MYSQL', '')
 
 class dool_plugin(dool):
     def __init__(self):

--- a/plugins/dool_innodb_io.py
+++ b/plugins/dool_innodb_io.py
@@ -16,6 +16,7 @@ class dool_plugin(dool):
         if os.access('/usr/bin/mysql', os.X_OK):
             try:
                 self.stdin, self.stdout, self.stderr = dpopen('/usr/bin/mysql -n %s' % mysql_options)
+                checkerrpipe(self.stderr, '.+')
             except IOError:
                 raise Exception('Cannot interface with MySQL binary')
             return True

--- a/plugins/dool_innodb_io.py
+++ b/plugins/dool_innodb_io.py
@@ -24,7 +24,7 @@ class dool_plugin(dool):
     def extract(self):
         try:
             self.stdin.write(b'show engine innodb status\\G\n')
-            line = matchpipe(self.stdout, '.*OS file reads,.*')
+            line = matchpipe(self.stdout, r'^\d+ OS file reads,')
 
             if line:
                 l = line.split()

--- a/plugins/dool_innodb_io.py
+++ b/plugins/dool_innodb_io.py
@@ -23,7 +23,7 @@ class dool_plugin(dool):
 
     def extract(self):
         try:
-            self.stdin.write(b'show engine innodb status\G\n')
+            self.stdin.write(b'show engine innodb status\\G\n')
             line = matchpipe(self.stdout, '.*OS file reads,.*')
 
             if line:

--- a/plugins/dool_innodb_ops.py
+++ b/plugins/dool_innodb_ops.py
@@ -1,7 +1,7 @@
 ### Author: Dag Wieers <dag$wieers,com>, Ming-Hung Chen <minghung.chen@gmail.com>
 
 global mysql_options
-mysql_options = os.getenv('DOOL_MYSQL')
+mysql_options = os.getenv('DOOL_MYSQL', '')
 
 class dool_plugin(dool):
     def __init__(self):

--- a/plugins/dool_innodb_ops.py
+++ b/plugins/dool_innodb_ops.py
@@ -16,6 +16,7 @@ class dool_plugin(dool):
         if os.access('/usr/bin/mysql', os.X_OK):
             try:
                 self.stdin, self.stdout, self.stderr = dpopen('/usr/bin/mysql -n %s' % mysql_options)
+                checkerrpipe(self.stderr, '.+')
             except IOError:
                 raise Exception('Cannot interface with MySQL binary')
             return True

--- a/plugins/dool_innodb_ops.py
+++ b/plugins/dool_innodb_ops.py
@@ -24,7 +24,7 @@ class dool_plugin(dool):
 
     def extract(self):
         try:
-            self.stdin.write(b'show engine innodb status\G\n')
+            self.stdin.write(b'SHOW ENGINE INNODB STATUS\\G\n')
             line = greppipe(self.stdout, 'Number of rows inserted')
 
             if line:

--- a/plugins/dool_mysql5_cmds.py
+++ b/plugins/dool_mysql5_cmds.py
@@ -51,7 +51,7 @@ class dool_plugin(dool):
         try:
             c = self.db.cursor()
             for name in self.vars:
-                c.execute("""show global status like '%s';""" % name)
+                c.execute("SHOW GLOBAL STATUS LIKE '%s'" % name)
                 line = c.fetchone()
                 if line[0] in self.vars:
                     if line[0] + 'raw' in self.set2:

--- a/plugins/dool_mysql5_conn.py
+++ b/plugins/dool_mysql5_conn.py
@@ -51,9 +51,9 @@ class dool_plugin(dool):
     def extract(self):
         try:
             c = self.db.cursor()
-            c.execute("""show global variables like 'max_connections';""")
+            c.execute("SHOW GLOBAL VARIABLES LIKE 'max_connections'")
             max = c.fetchone()
-            c.execute("""show global status like 'Threads_connected';""")
+            c.execute("SHOW GLOBAL STATUS LIKE 'Threads_connected'")
             thread = c.fetchone()
             if thread[0] in self.vars:
                 self.set2[thread[0]] = float(thread[1])

--- a/plugins/dool_mysql5_innodb.py
+++ b/plugins/dool_mysql5_innodb.py
@@ -1,7 +1,7 @@
 ### Author: HIROSE Masaaki <hirose31 _at_ gmail.com>, Ming-Hung Chen <minghung.chen@gmail.com>
 
 global mysql_options
-mysql_options = os.getenv('DOOL_MYSQL') or ''
+mysql_options = os.getenv('DOOL_MYSQL', '')
 
 global target_status
 global _basic_status

--- a/plugins/dool_mysql5_innodb.py
+++ b/plugins/dool_mysql5_innodb.py
@@ -92,7 +92,7 @@ class dool_plugin(dool):
 
     def extract(self):
         try:
-            self.stdin.write(b'show global status;\n')
+            self.stdin.write(b'SHOW GLOBAL STATUS;\n')
             for line in readpipe(self.stdout):
                 if line == '':
                     break

--- a/plugins/dool_mysql5_innodb.py
+++ b/plugins/dool_mysql5_innodb.py
@@ -1,7 +1,7 @@
 ### Author: HIROSE Masaaki <hirose31 _at_ gmail.com>, Ming-Hung Chen <minghung.chen@gmail.com>
 
 global mysql_options
-mysql_options = os.getenv('DSTAT_MYSQL') or ''
+mysql_options = os.getenv('DOOL_MYSQL') or ''
 
 global target_status
 global _basic_status
@@ -45,7 +45,7 @@ gauge = {
     'Threads_running'                 : 1,
     }
 
-class dstat_plugin(dstat):
+class dool_plugin(dool):
     """
     mysql5-innodb, mysql5-innodb-basic, mysql5-innodb-extra
 

--- a/plugins/dool_mysql5_innodb.py
+++ b/plugins/dool_mysql5_innodb.py
@@ -84,6 +84,7 @@ class dool_plugin(dool):
         if mysql_cmd:
             try:
                 self.stdin, self.stdout, self.stderr = dpopen('%s -n %s' % (mysql_cmd, mysql_options))
+                checkerrpipe(self.stderr, '.+')
             except IOError:
                 raise Exception('Cannot interface with MySQL binary')
             return True

--- a/plugins/dool_mysql5_io.py
+++ b/plugins/dool_mysql5_io.py
@@ -48,7 +48,7 @@ class dool_plugin(dool):
     def extract(self):
         try:
             c = self.db.cursor()
-            c.execute("""show global status like 'Bytes_%';""")
+            c.execute("SHOW GLOBAL STATUS LIKE 'Bytes_%'")
             lines = c.fetchall()
             for line in lines:
                 if len(line[1]) < 2: continue

--- a/plugins/dool_mysql5_keys.py
+++ b/plugins/dool_mysql5_keys.py
@@ -51,7 +51,7 @@ class dool_plugin(dool):
     def extract(self):
         try:
             c = self.db.cursor()
-            c.execute("""show global status like 'Key_%';""")
+            c.execute("SHOW GLOBAL STATUS LIKE 'Key_%'")
             lines = c.fetchall()
             for line in lines:
                 if len(line[1]) < 2: continue

--- a/plugins/dool_mysql_io.py
+++ b/plugins/dool_mysql_io.py
@@ -1,7 +1,7 @@
 ### Author: Dag Wieers <dag$wieers,com>, Ming-Hung Chen <minghung.chen@gmail.com>
 
 global mysql_options
-mysql_options = os.getenv('DOOL_MYSQL')
+mysql_options = os.getenv('DOOL_MYSQL', '')
 
 class dool_plugin(dool):
     def __init__(self):

--- a/plugins/dool_mysql_io.py
+++ b/plugins/dool_mysql_io.py
@@ -37,7 +37,7 @@ class dool_plugin(dool):
             for name in self.vars: self.val[name] = -1
 
         except Exception as e:
-            if op.debug > 1: print('dstat_innodb_buffer: exception', e)
+            if op.debug > 1: print('dool_mysql_io: exception', e)
             for name in self.vars: self.val[name] = -1
 
 # vim:ts=4:sw=4:et

--- a/plugins/dool_mysql_io.py
+++ b/plugins/dool_mysql_io.py
@@ -14,6 +14,7 @@ class dool_plugin(dool):
             raise Exception('Needs MySQL binary')
         try:
             self.stdin, self.stdout, self.stderr = dpopen('/usr/bin/mysql -n %s' % mysql_options)
+            checkerrpipe(self.stderr, '.+')
         except IOError:
             raise Exception('Cannot interface with MySQL binary')
 

--- a/plugins/dool_mysql_keys.py
+++ b/plugins/dool_mysql_keys.py
@@ -1,7 +1,7 @@
 ### Author: Dag Wieers <dag$wieers,com>, Ming-Hung Chen <minghung.chen@gmail.com>
 
 global mysql_options
-mysql_options = os.getenv('DOOL_MYSQL')
+mysql_options = os.getenv('DOOL_MYSQL', '')
 
 class dool_plugin(dool):
     def __init__(self):

--- a/plugins/dool_mysql_keys.py
+++ b/plugins/dool_mysql_keys.py
@@ -17,6 +17,7 @@ class dool_plugin(dool):
             raise Exception('Needs MySQL binary')
         try:
             self.stdin, self.stdout, self.stderr = dpopen('/usr/bin/mysql -n %s' % mysql_options)
+            checkerrpipe(self.stderr, '.+')
         except IOError:
             raise Exception('Cannot interface with MySQL binary')
 


### PR DESCRIPTION
* Replace more dstat to dool
* Fix bytes-to-str concat error in grep-/matchpipe
* Fix invalid escape sequence warning in InnoDB status commands
* Fix unknown database error on empty DOOL_MYSQL environment variable
* Do not hang if connecting w/o correct credentials but print error message
* Add suggestion for package python3-mysqldb which is needed for some of the mysql5 plugins

Fixes #103