### PR TITLE
Read defaults file for Python MySQL connections

### DIFF
--- a/plugins/dool_mysql5_cmds.py
+++ b/plugins/dool_mysql5_cmds.py
@@ -1,7 +1,7 @@
 ### Author: <lefred@inuits.be>
 
 global mysql_user
-mysql_user = os.getenv('DOOL_MYSQL_USER') or os.getenv('USER')
+mysql_user = os.getenv('DOOL_MYSQL_USER')
 
 global mysql_pwd
 mysql_pwd = os.getenv('DOOL_MYSQL_PWD')
@@ -14,6 +14,12 @@ mysql_port = os.getenv('DOOL_MYSQL_PORT')
 
 global mysql_socket
 mysql_socket = os.getenv('DOOL_MYSQL_SOCKET')
+
+global read_default_file
+read_default_file = os.getenv('DOOL_MYSQL_DEFAULTS_FILE')
+
+global read_default_group
+read_default_group = os.getenv('DOOL_MYSQL_DEFAULTS_GROUP')
 
 class dool_plugin(dool):
     """
@@ -31,7 +37,10 @@ class dool_plugin(dool):
         global MySQLdb
         import MySQLdb
         try:
-            args = {}
+            args = {
+                    'read_default_group': 'client',
+                    'read_default_file': os.path.expanduser('~/.my.cnf'),
+                    }
             if mysql_user:
                 args['user'] = mysql_user
             if mysql_pwd:
@@ -42,6 +51,10 @@ class dool_plugin(dool):
                 args['port'] = mysql_port
             if mysql_socket:
                 args['unix_socket'] = mysql_socket
+            if read_default_file:
+                args['read_default_file'] = read_default_file
+            if read_default_group:
+                args['read_default_group'] = read_default_group
 
             self.db = MySQLdb.connect(**args)
         except Exception as e:

--- a/plugins/dool_mysql5_conn.py
+++ b/plugins/dool_mysql5_conn.py
@@ -1,7 +1,7 @@
 ### Author: <lefred$inuits,be>
 
 global mysql_user
-mysql_user = os.getenv('DOOL_MYSQL_USER') or os.getenv('USER')
+mysql_user = os.getenv('DOOL_MYSQL_USER')
 
 global mysql_pwd
 mysql_pwd = os.getenv('DOOL_MYSQL_PWD')
@@ -14,6 +14,12 @@ mysql_port = os.getenv('DOOL_MYSQL_PORT')
 
 global mysql_socket
 mysql_socket = os.getenv('DOOL_MYSQL_SOCKET')
+
+global read_default_file
+read_default_file = os.getenv('DOOL_MYSQL_DEFAULTS_FILE')
+
+global read_default_group
+read_default_group = os.getenv('DOOL_MYSQL_DEFAULTS_GROUP')
 
 class dool_plugin(dool):
     """
@@ -32,7 +38,10 @@ class dool_plugin(dool):
         global MySQLdb
         import MySQLdb
         try:
-            args = {}
+            args = {
+                    'read_default_group': 'client',
+                    'read_default_file': os.path.expanduser('~/.my.cnf'),
+                    }
             if mysql_user:
                 args['user'] = mysql_user
             if mysql_pwd:
@@ -43,6 +52,10 @@ class dool_plugin(dool):
                 args['port'] = mysql_port
             if mysql_socket:
                 args['unix_socket'] = mysql_socket
+            if read_default_file:
+                args['read_default_file'] = read_default_file
+            if read_default_group:
+                args['read_default_group'] = read_default_group
 
             self.db = MySQLdb.connect(**args)
         except Exception as e:

--- a/plugins/dool_mysql5_io.py
+++ b/plugins/dool_mysql5_io.py
@@ -1,7 +1,7 @@
 ### Author: <lefred$inuits,be>
 
 global mysql_user
-mysql_user = os.getenv('DOOL_MYSQL_USER') or os.getenv('USER')
+mysql_user = os.getenv('DOOL_MYSQL_USER')
 
 global mysql_pwd
 mysql_pwd = os.getenv('DOOL_MYSQL_PWD')
@@ -14,6 +14,12 @@ mysql_port = os.getenv('DOOL_MYSQL_PORT')
 
 global mysql_socket
 mysql_socket = os.getenv('DOOL_MYSQL_SOCKET')
+
+global read_default_file
+read_default_file = os.getenv('DOOL_MYSQL_DEFAULTS_FILE')
+
+global read_default_group
+read_default_group = os.getenv('DOOL_MYSQL_DEFAULTS_GROUP')
 
 class dool_plugin(dool):
     """
@@ -29,7 +35,10 @@ class dool_plugin(dool):
         global MySQLdb
         import MySQLdb
         try:
-            args = {}
+            args = {
+                    'read_default_group': 'client',
+                    'read_default_file': os.path.expanduser('~/.my.cnf'),
+                    }
             if mysql_user:
                 args['user'] = mysql_user
             if mysql_pwd:
@@ -40,10 +49,14 @@ class dool_plugin(dool):
                 args['port'] = mysql_port
             if mysql_socket:
                 args['unix_socket'] = mysql_socket
+            if read_default_file:
+                args['read_default_file'] = read_default_file
+            if read_default_group:
+                args['read_default_group'] = read_default_group
 
             self.db = MySQLdb.connect(**args)
-        except:
-            raise Exception('Cannot interface with MySQL server')
+        except Exception as e:
+            raise Exception('Cannot interface with MySQL server: %s' % e)
 
     def extract(self):
         try:

--- a/plugins/dool_mysql5_keys.py
+++ b/plugins/dool_mysql5_keys.py
@@ -1,7 +1,7 @@
 ### Author: <lefred$inuits,be>
 
 global mysql_user
-mysql_user = os.getenv('DOOL_MYSQL_USER') or os.getenv('USER')
+mysql_user = os.getenv('DOOL_MYSQL_USER')
 
 global mysql_pwd
 mysql_pwd = os.getenv('DOOL_MYSQL_PWD') 
@@ -14,6 +14,12 @@ mysql_port = os.getenv('DOOL_MYSQL_PORT')
 
 global mysql_socket
 mysql_socket = os.getenv('DOOL_MYSQL_SOCKET')
+
+global read_default_file
+read_default_file = os.getenv('DOOL_MYSQL_DEFAULTS_FILE')
+
+global read_default_group
+read_default_group = os.getenv('DOOL_MYSQL_DEFAULTS_GROUP')
 
 class dool_plugin(dool):
     """
@@ -32,7 +38,10 @@ class dool_plugin(dool):
         global MySQLdb
         import MySQLdb
         try:
-            args = {}
+            args = {
+                    'read_default_group': 'client',
+                    'read_default_file': os.path.expanduser('~/.my.cnf'),
+                    }
             if mysql_user:
                 args['user'] = mysql_user
             if mysql_pwd:
@@ -43,10 +52,14 @@ class dool_plugin(dool):
                 args['port'] = mysql_port
             if mysql_socket:
                 args['unix_socket'] = mysql_socket
+            if read_default_file:
+                args['read_default_file'] = read_default_file
+            if read_default_group:
+                args['read_default_group'] = read_default_group
 
             self.db = MySQLdb.connect(**args)
-        except:
-            raise Exception('Cannot interface with MySQL server')
+        except Exception as e:
+            raise Exception('Cannot interface with MySQL server: %s' % e)
 
     def extract(self):
         try:


### PR DESCRIPTION
##### DOOL VERSION
<!--- Paste Dool version here -->

##### SUMMARY
<!--- Describe the change here, including rationale and design decisions -->
Read MySQL defaults file from user's home directory as `mysql` CLI does and let user specify file and group in file via environment variables.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

```
<!--- Paste verbatim command output here, e.g. before and after your change -->
```
