### PR TITLE
Support running on macOS

### DIFF
--- a/dool
+++ b/dool
@@ -1843,6 +1843,13 @@ def set_theme():
 
 def ticks():
     "Return the number of 'ticks' since bootup"
+    if os.uname().sysname in ['Darwin', 'FreeBSD']:
+        import subprocess
+        boottime = subprocess.check_output(['sysctl', '-n', 'kern.boottime'])
+        boottime = boottime.decode().split()[3:7]
+        boottime = float(f'{boottime[0].rstrip(",")}.{boottime[3]}')
+        return time.time() - boottime
+
     try:
         for line in open('/proc/uptime', 'r').readlines():
             l = line.split()

--- a/dool
+++ b/dool
@@ -396,7 +396,7 @@ class Options:
         print('Homepage at https://github.com/scottchiefbaker/dool/')
         print()
         print('Platform %s/%s' % (os.name, sys.platform))
-        print('Kernel %s' % os.uname()[2])
+        print('Kernel %s' % os.uname().release)
         print('Python %s' % sys.version)
         print()
 
@@ -2753,7 +2753,7 @@ def main():
     pagesize = resource.getpagesize()
     interval = 1
     user     = getpass.getuser()
-    hostname = os.uname()[1]
+    hostname = os.uname().nodename
 
     ### Write term-title
     if sys.stdout.isatty():


### PR DESCRIPTION
##### DOOL VERSION
`next`

##### SUMMARY
<!--- Describe the change here, including rationale and design decisions -->
Allow running `dool` on FreeBSD and macOS to allow easier development of plugins on these platform.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Before this change, `dool` just hangs.