### PR TITLE
plugins/mysql5-cmds: Fetch all variables at once

### DIFF
--- a/plugins/dool_mysql5_cmds.py
+++ b/plugins/dool_mysql5_cmds.py
@@ -26,10 +26,10 @@ class dool_plugin(dool):
     Plugin for MySQL 5 commands.
     """
     def __init__(self):
-        self.name = 'mysql5 cmds'
-        self.nick = ('sel', 'ins','upd','del')
-        self.vars = ('Com_select', 'Com_insert','Com_update','Com_delete')
-        self.type = 'd'
+        self.name  = 'mysql5 cmds'
+        self.nick  = ('sel', 'ins','upd','del')
+        self.vars  = ('Com_select', 'Com_insert','Com_update','Com_delete')
+        self.type  = 'd'
         self.width = 5
         self.scale = 1
 
@@ -63,13 +63,12 @@ class dool_plugin(dool):
     def extract(self):
         try:
             c = self.db.cursor()
-            for name in self.vars:
-                c.execute("SHOW GLOBAL STATUS LIKE '%s'" % name)
-                line = c.fetchone()
-                if line[0] in self.vars:
-                    if line[0] + 'raw' in self.set2:
-                        self.set2[line[0]] = int(line[1]) - self.set2[line[0] + 'raw']
-                    self.set2[line[0] + 'raw'] = int(line[1])
+            c.execute("SHOW GLOBAL STATUS WHERE Variable_name IN %s" % str(self.vars))
+            for name, val in c.fetchall():
+                if name in self.vars:
+                    if name + 'raw' in self.set2:
+                        self.set2[name] = int(val) - self.set2[name + 'raw']
+                    self.set2[name + 'raw'] = int(val)
 
             for name in self.vars:
                 self.val[name] = self.set2[name] * 1.0 / elapsed


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change here, including rationale and design decisions -->
Only do one round trip to get statistics.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
To some server over the network:
before
```
snooze┬┄┄┄┄┄┄mysql5┄cmds┄┄┄┄┄┄
snooze│ sel   ins   upd   del
     -│    0     0     0     0 99.70ms
0.9956│    0     2     0     0116.71ms
1.0011│   12     1     0     0 79.13ms
0.9960│    0     1     0     0121.40ms
```

after
```
snooze┬┄┄┄┄┄┄mysql5┄cmds┄┄┄┄┄┄
snooze│ sel   ins   upd   del
     -│    0     0     0     0 41.69ms
0.9947│    0     1     0     0 35.34ms
0.9980│   10     2     0     0 31.43ms
1.0000│    0     0     0     0 19.92ms
```
