### PR TITLE
Fix profile.run()

### DIFF
--- a/dool
+++ b/dool
@@ -3277,7 +3277,7 @@ def start_profiling():
     if os.path.exists(op.profile):
         os.remove(op.profile)
 
-    profile.run('main()', op.profile)
+    profile.runctx('main()', globals(), locals(), op.profile)
 
 # Find the text between two delimeters (defaults to parens)
 def extract_between_parens(text, start_delim = '(', end_delim = ')'):


### PR DESCRIPTION
More recent versions of Python require that (at least when using a virtualenv) globals and locals are copied into the new context where the profiler runs. Use `profile.runctx()` to pass these.

##### DOOL VERSION
1.3.9

##### SUMMARY
`globals` and `locals` need to be passed explicitly when running the profiler, at least when using a `virtualenv`.


Fixes #112 

Before change:
```
dool --profile
Using default plugins: cpu, disk, net, load
Traceback (most recent call last):
  File "/home/marcel/code/dool/venv/bin/dool", line 8, in <module>
    sys.exit(__main__.__main())
             ^^^^^^^^^^^^^^^^^
  File "/home/marcel/code/dool/venv/lib/python3.12/site-packages/dool/__main__.py", line 3324, in __main
    start_profiling()
  File "/home/marcel/code/dool/venv/lib/python3.12/site-packages/dool/__main__.py", line 3280, in start_profiling
    profile.run('main()', op.profile)
  File "/usr/lib/python3.12/profile.py", line 93, in run
    return _Utils(Profile).run(statement, filename, sort)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/profile.py", line 55, in run
    prof.run(statement)
  File "/usr/lib/python3.12/profile.py", line 418, in run
    return self.runctx(cmd, dict, dict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/profile.py", line 424, in runctx
    exec(cmd, globals, locals)
  File "<string>", line 1, in <module>
NameError: name 'main' is not defined. Did you mean: 'min'?
```

After change:
```
dool --profile
Using default plugins: cpu, disk, net, load
Warning: Plugin dool_net failed to load. (underlying stream is not seekable)
┄┄total┄cpu┄usage┄┄┬┄dsk/total┄┬┄┄┄load┄avg┄┄┄┬┄┄┄┄┄system┄┄┄┄
usr sys idl wai stl│ read  writ│ 1m   5m  15m │      time     
  1   1  98   0   0│ 595k 3464k│0.36 0.46 0.51│Mar-09 11:22:10
  1   0  99   0   0│   0     0 │0.36 0.46 0.51│Mar-09 11:22:11        
Mon Mar  9 11:22:12 2026    dool_profile.log

         2247 function calls (2198 primitive calls) in 0.005 seconds

   Ordered by: cumulative time
   List reduced from 261 to 53 due to restriction <53>

[... output elided ...]
```