### PR TITLE
Add site-packages directory to pluginpath

### DIFF
--- a/dool
+++ b/dool
@@ -39,6 +39,7 @@ import sched
 import sys
 import time
 import signal
+import sysconfig
 
 from collections.abc import Sequence
 
@@ -49,6 +50,7 @@ theme = { 'default': '' }
 pluginpath = [
     os.path.expanduser('~/.dool/'),                           # home + /.dool/
     os.path.dirname(os.path.abspath(__file__)) + '/plugins/', # binary path + /plugins/
+    sysconfig.get_path('purelib') + '/dool/plugins/',
     '/usr/share/dool/',
     '/usr/local/share/dool/',
 ]


### PR DESCRIPTION
This is one part of https://github.com/scottchiefbaker/dool/pull/80 which I hope to eventually fix, as it prevents dool from being packaged in Gentoo (see https://bugs.gentoo.org/781173).