### PR TITLE
Fix CSV formula injection in top-plugin output

### DIFF
--- a/dool
+++ b/dool
@@ -3032,7 +3032,10 @@ def perform(update):
 
             # Prep the line for the CSV file
             if op.output and step == op.delay:
-                oline = oline + o.showcsv() + o.showcsvend(totlist, vislist)
+                csv_cell = o.showcsv()
+                if o.type == 's' and len(o.vars) == 1:
+                    csv_cell = csv_quote_string_cell(csv_cell)
+                oline = oline + csv_cell + o.showcsvend(totlist, vislist)
 
         ### Put the output in the csv file
         if op.output and step == op.delay:
@@ -3171,6 +3174,12 @@ def file_slurp(filename, size = -1):
         fd.close()
 
     return ret
+
+def csv_quote_string_cell(text):
+    "Quote free-form CSV string cells and neutralize spreadsheet formulas"
+    if text and text[0] in ('=', '+', '-', '@'):
+        text = "'" + text
+    return '"' + text.replace('"', '""') + '"'
 
 # Make human readable device names that are shorter
 #


### PR DESCRIPTION
## Summary
- fix a security issue in CSV output generated by top-process plugins
- quote single-field string CSV output so embedded commas and quotes stay inside one field
- neutralize values that begin with spreadsheet formula prefixes before serializing them
- preserve existing numeric and multi-column CSV formatting paths

## Security context
This change addresses CSV formula injection in top-plugin output. A process name beginning with spreadsheet formula prefixes, or containing embedded CSV separators crafted to create a new formula cell, could be written into exported CSV in a way that spreadsheet software may interpret dangerously when the file is opened.

## Testing
- reproduced the original top-plugin CSV issue on Linux with a process name beginning with '='
- verified the generated CSV now emits a quoted field prefixed with '\'' instead of a raw formula cell
- verified a payload containing embedded commas such as foobar',=payload,'test remains inside one quoted CSV field
