### PR TITLE
Fix symlink overwrite in --devel log handling

### DIFF
--- a/dool
+++ b/dool
@@ -2134,7 +2134,11 @@ def devel_log(msg):
     if not DEBUG_FH:
         log_file = "/tmp/dool-devel.log"
         print("Writing devel log: '%s'" % log_file)
-        DEBUG_FH = open(log_file, "w", 1)
+        flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+        if hasattr(os, 'O_NOFOLLOW'):
+            flags |= os.O_NOFOLLOW
+        fd = os.open(log_file, flags, 0o600)
+        DEBUG_FH = os.fdopen(fd, "w", 1)
 
         # Print out the header line for the devel log
         DEBUG_FH.write("|Time          |Since Prev |Description|\n");


### PR DESCRIPTION
## Summary
- fix a security issue in --devel log file handling
- refuse symlinked /tmp/dool-devel.log paths by opening the log with O_NOFOLLOW
- preserve the existing debug log behavior for normal files

## Security context
This change addresses a local symlink overwrite issue in the devel logging path. An attacker who pre-creates /tmp/dool-devel.log as a symlink could cause dool to follow that link and overwrite another file writable by the user running dool.

## Testing
- reproduced the original symlink issue on Linux by linking /tmp/dool-devel.log to another file
- verified the target file is no longer overwritten after this change
- verified dool now aborts with an error instead of following the symlink
