### PR TITLE
Modernize Condor command handling for Python 3

### DIFF
--- a/dool
+++ b/dool
@@ -1971,21 +1971,24 @@ def matchpipe(fileobj, string, tmout = 0.001):
 
 # Test if a command is capable of being run
 def cmd_test(cmd):
-    pipes = os.popen3(cmd, 't', 0)
-    for line in pipes[2].readlines():
-        raise Exception(line.strip())
+    import subprocess
+    p = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    if p.returncode != 0 and p.stderr:
+        raise Exception(p.stderr.strip())
 
 # Read command output line by line
 def cmd_readlines(cmd):
-    pipes = os.popen3(cmd, 't', 0)
-    for line in pipes[1].readlines():
-       yield line
+    import subprocess
+    p = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    for line in p.stdout.splitlines(keepends=True):
+        yield line
 
 # Read command output column by column
 def cmd_splitlines(cmd, sep=None):
-    pipes = os.popen3(cmd, 't', 0)
-    for line in pipes[1].readlines():
-       yield line.split(sep)
+    import subprocess
+    p = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    for line in p.stdout.splitlines():
+        yield line.split(sep)
 
 def proc_readlines(filename):
     "Return the lines of a file, one by one"

--- a/plugins/dool_condor_queue.py
+++ b/plugins/dool_condor_queue.py
@@ -38,7 +38,8 @@ class condor_classad:
     def __getitem__(self, name):
         if name in self.attributes:
             self._expand(name)
-        return self.attributes[name]
+            return self.attributes[name]
+        return None
 
     def _expand(self, var):
         if not var in self.attributes:
@@ -89,13 +90,13 @@ class dool_plugin(dool):
         self.condor_config = None
 
     def check(self):
-        config_file = os.environ['CONDOR_CONFIG']
-        if config_file == None:
-            raise Exception('Environment varibale CONDOR_CONFIG is missing')
+        config_file = os.environ.get('CONDOR_CONFIG')
+        if config_file is None:
+            raise Exception('Environment variable CONDOR_CONFIG is missing')
         self.condor_config = condor_classad(config_file)
 
         bin_dir = self.condor_config['BIN']
-        if bin_dir == None:
+        if bin_dir is None:
             raise Exception('Unable to find BIN directory in condor config file %s' % config_file)
 
         self.condor_status_cmd = os.path.join(bin_dir, 'condor_q')
@@ -104,9 +105,9 @@ class dool_plugin(dool):
             raise Exception('Needs %s in the path' % self.condor_status_cmd)
         else:
             try:
-                p = os.popen(self.condor_status_cmd+' 2>&1 /dev/null')
-                ret = p.close()
-                if ret:
+                import subprocess
+                ret = subprocess.run([self.condor_status_cmd], stderr=subprocess.DEVNULL).returncode
+                if ret != 0:
                     raise Exception('Cannot interface with Condor - condor_q returned != 0?')
             except IOError:
                 raise Exception('Unable to execute %s' % self.condor_status_cmd)
@@ -117,12 +118,13 @@ class dool_plugin(dool):
 
         try:
             for repeats in range(3):
-                for last_line in cmd_readlines(self.condor_status_cmd):
-                    pass
+                import subprocess
+                result = subprocess.run([self.condor_status_cmd], capture_output=True, text=True)
+                last_line = result.stdout.splitlines()[-1] if result.stdout.strip() else None
 
                 m = CONDOR_Q_STAT_PATTER.match(last_line)
                 if m == None:
-                    raise Exception('Invalid output from %s. Got: %s' % (cmd, last_line))
+                    raise Exception('Invalid output from %s. Got: %s' % (self.condor_status_cmd, last_line))
 
                 stats = [int(s.strip()) for s in m.groups()]
                 for i,j in enumerate(self.vars):


### PR DESCRIPTION
## Summary

- replace legacy os.popen3() helper usage with Python 3-compatible subprocess.run()
- fix Condor plugin handling for missing CONDOR_CONFIG
- fix Condor config attribute lookups so missing keys return None as callers expect
- stop invoking the shell for Condor command execution when running a single binary path

## Problem

The Condor plugin and related helper code have several non-security runtime issues:

- cmd_test(), cmd_readlines(), and cmd_splitlines() use os.popen3(), which does not exist in Python 3
- plugins/dool_condor_queue.py uses os.environ['CONDOR_CONFIG'], so a missing variable raises KeyError before the intended error handling runs
- condor_classad.__getitem__() raises KeyError for missing attributes, even though callers expect None
- the Condor plugin passes a config-derived executable path through the shell unnecessarily, which breaks paths containing spaces and adds avoidable fragility

## Changes

- update cmd_test(), cmd_readlines(), and cmd_splitlines() to use subprocess.run()
- change CONDOR_CONFIG lookup to os.environ.get() so the intended missing-variable error path works
- change condor_classad.__getitem__() to return None for missing keys
- execute condor_q directly via subprocess.run() in the Condor plugin instead of going through the shell
- fix the Condor plugin error path so invalid output reports the actual command being run
