### PR TITLE
Replace os.popen3 helpers with subprocess.run

### DIFF
--- a/dool
+++ b/dool
@@ -1971,21 +1971,24 @@ def matchpipe(fileobj, string, tmout = 0.001):
 
 # Test if a command is capable of being run
 def cmd_test(cmd):
-    pipes = os.popen3(cmd, 't', 0)
-    for line in pipes[2].readlines():
-        raise Exception(line.strip())
+    import subprocess
+    p = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    if p.returncode != 0 and p.stderr:
+        raise Exception(p.stderr.strip())
 
 # Read command output line by line
 def cmd_readlines(cmd):
-    pipes = os.popen3(cmd, 't', 0)
-    for line in pipes[1].readlines():
-       yield line
+    import subprocess
+    p = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    for line in p.stdout.splitlines(keepends=True):
+        yield line
 
 # Read command output column by column
 def cmd_splitlines(cmd, sep=None):
-    pipes = os.popen3(cmd, 't', 0)
-    for line in pipes[1].readlines():
-       yield line.split(sep)
+    import subprocess
+    p = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    for line in p.stdout.splitlines():
+        yield line.split(sep)
 
 def proc_readlines(filename):
     "Return the lines of a file, one by one"

--- a/dool
+++ b/dool
@@ -36,6 +36,7 @@ import os
 import re
 import resource
 import sched
+import subprocess
 import sys
 import time
 import signal
@@ -1971,21 +1972,18 @@ def matchpipe(fileobj, string, tmout = 0.001):
 
 # Test if a command is capable of being run
 def cmd_test(cmd):
-    import subprocess
     p = subprocess.run(cmd, shell=True, capture_output=True, text=True)
-    if p.returncode != 0 and p.stderr:
+    if p.stderr:
         raise Exception(p.stderr.strip())
 
 # Read command output line by line
 def cmd_readlines(cmd):
-    import subprocess
     p = subprocess.run(cmd, shell=True, capture_output=True, text=True)
     for line in p.stdout.splitlines(keepends=True):
         yield line
 
 # Read command output column by column
 def cmd_splitlines(cmd, sep=None):
-    import subprocess
     p = subprocess.run(cmd, shell=True, capture_output=True, text=True)
     for line in p.stdout.splitlines():
         yield line.split(sep)

--- a/dool
+++ b/dool
@@ -1980,13 +1980,13 @@ def cmd_test(cmd):
 def cmd_readlines(cmd):
     p = subprocess.run(cmd, shell=True, capture_output=True, text=True)
     for line in p.stdout.splitlines(keepends=True):
-        yield line
+       yield line
 
 # Read command output column by column
 def cmd_splitlines(cmd, sep=None):
     p = subprocess.run(cmd, shell=True, capture_output=True, text=True)
     for line in p.stdout.splitlines():
-        yield line.split(sep)
+       yield line.split(sep)
 
 def proc_readlines(filename):
     "Return the lines of a file, one by one"


### PR DESCRIPTION
## Summary

- replace legacy os.popen3() helper usage with Python 3-compatible subprocess.run()

## Problem

The shared command helpers in dool still use os.popen3(), which does not exist in Python 3. Any code path that relies on cmd_test(), cmd_readlines(), or cmd_splitlines() can fail at runtime because of that obsolete interface.

## Changes

- update cmd_test() to use subprocess.run()
- update cmd_readlines() to yield lines from subprocess.run(..., capture_output=True, text=True)
- update cmd_splitlines() to split stdout from subprocess.run()
