### PR TITLE
Improve Condor plugin runtime handling

### DIFF
--- a/plugins/dool_condor_queue.py
+++ b/plugins/dool_condor_queue.py
@@ -9,6 +9,7 @@
 
 import os
 import re
+import subprocess
 
 global condor_classad
 
@@ -105,8 +106,11 @@ class dool_plugin(dool):
             raise Exception('Needs %s in the path' % self.condor_status_cmd)
         else:
             try:
-                import subprocess
-                ret = subprocess.run([self.condor_status_cmd], stderr=subprocess.DEVNULL).returncode
+                ret = subprocess.run(
+                    [self.condor_status_cmd],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                ).returncode
                 if ret != 0:
                     raise Exception('Cannot interface with Condor - condor_q returned != 0?')
             except IOError:
@@ -118,7 +122,6 @@ class dool_plugin(dool):
 
         try:
             for repeats in range(3):
-                import subprocess
                 result = subprocess.run([self.condor_status_cmd], capture_output=True, text=True)
                 last_line = result.stdout.splitlines()[-1] if result.stdout.strip() else None
 

--- a/plugins/dool_condor_queue.py
+++ b/plugins/dool_condor_queue.py
@@ -38,7 +38,8 @@ class condor_classad:
     def __getitem__(self, name):
         if name in self.attributes:
             self._expand(name)
-        return self.attributes[name]
+            return self.attributes[name]
+        return None
 
     def _expand(self, var):
         if not var in self.attributes:
@@ -89,13 +90,13 @@ class dool_plugin(dool):
         self.condor_config = None
 
     def check(self):
-        config_file = os.environ['CONDOR_CONFIG']
-        if config_file == None:
-            raise Exception('Environment varibale CONDOR_CONFIG is missing')
+        config_file = os.environ.get('CONDOR_CONFIG')
+        if config_file is None:
+            raise Exception('Environment variable CONDOR_CONFIG is missing')
         self.condor_config = condor_classad(config_file)
 
         bin_dir = self.condor_config['BIN']
-        if bin_dir == None:
+        if bin_dir is None:
             raise Exception('Unable to find BIN directory in condor config file %s' % config_file)
 
         self.condor_status_cmd = os.path.join(bin_dir, 'condor_q')
@@ -104,9 +105,9 @@ class dool_plugin(dool):
             raise Exception('Needs %s in the path' % self.condor_status_cmd)
         else:
             try:
-                p = os.popen(self.condor_status_cmd+' 2>&1 /dev/null')
-                ret = p.close()
-                if ret:
+                import subprocess
+                ret = subprocess.run([self.condor_status_cmd], stderr=subprocess.DEVNULL).returncode
+                if ret != 0:
                     raise Exception('Cannot interface with Condor - condor_q returned != 0?')
             except IOError:
                 raise Exception('Unable to execute %s' % self.condor_status_cmd)
@@ -117,12 +118,13 @@ class dool_plugin(dool):
 
         try:
             for repeats in range(3):
-                for last_line in cmd_readlines(self.condor_status_cmd):
-                    pass
+                import subprocess
+                result = subprocess.run([self.condor_status_cmd], capture_output=True, text=True)
+                last_line = result.stdout.splitlines()[-1] if result.stdout.strip() else None
 
                 m = CONDOR_Q_STAT_PATTER.match(last_line)
                 if m == None:
-                    raise Exception('Invalid output from %s. Got: %s' % (cmd, last_line))
+                    raise Exception('Invalid output from %s. Got: %s' % (self.condor_status_cmd, last_line))
 
                 stats = [int(s.strip()) for s in m.groups()]
                 for i,j in enumerate(self.vars):


### PR DESCRIPTION
## Summary

- fix Condor plugin handling for missing CONDOR_CONFIG
- fix Condor config attribute lookups so missing keys return None as callers expect
- stop invoking the shell for Condor command execution when running a single binary path
- fix the Condor plugin error path so invalid output reports the actual command being run

## Problem

The Condor plugin has several runtime issues independent of the shared command helper layer:

- plugins/dool_condor_queue.py uses os.environ['CONDOR_CONFIG'], so a missing variable raises KeyError before the intended error handling runs
- condor_classad.__getitem__() raises KeyError for missing attributes, even though callers expect None
- the Condor plugin passes a config-derived executable path through the shell unnecessarily, which breaks paths containing spaces and adds avoidable fragility
- the invalid-output error path references the wrong command variable

## Changes

- change CONDOR_CONFIG lookup to os.environ.get()
- change condor_classad.__getitem__() to return None for missing keys
- execute condor_q directly via subprocess.run() in the Condor plugin instead of going through the shell
- fix the Condor plugin error path so invalid output reports the actual command being run
