### PR TITLE
Remove unused --pidfile option

### DIFF
--- a/dool
+++ b/dool
@@ -86,7 +86,6 @@ class Options:
         self.update        = True
         self.header        = True
         self.output        = False
-        self.pidfile       = False
         self.profile       = ''
         self.use_ascii     = False
         self.plugin_params = {} # Not currently used
@@ -121,7 +120,7 @@ class Options:
         ]
 
         param_opts = [
-            'diskset=' , 'output='    , 'pidfile='
+            'diskset=' , 'output='
         ]
 
         all_opts = (long_opts + param_opts + plugin_opt_list)
@@ -268,8 +267,6 @@ class Options:
                 self.display = False
             elif opt in ['--display']:
                 self.display = True
-            elif opt in ['--pidfile']:
-                self.pidfile = arg
             elif opt in ['--profile']:
                 self.profile = 'dool_profile.log'
             elif opt in ['--devel']:
@@ -2339,10 +2336,6 @@ def exit(ret):
     sys.stdout.write(ansi['reset'])
     sys.stdout.flush()
 
-    # Remove any pidfiles
-    if op.pidfile and os.path.exists(op.pidfile):
-        os.remove(op.pidfile)
-
     if op.profile and os.path.exists(op.profile):
         rows, cols = get_term_size()
         import pstats
@@ -2830,16 +2823,6 @@ def main():
 
         header = ('"Cmdline:"','"' + run_cmd + '"','','','','"Date:"','"%s"\n' % time.strftime('%d %b %Y %H:%M:%S %Z', time.localtime()))
         outputfile.write(char['sep'].join(header))
-
-    ### Create pidfile
-    if op.pidfile:
-        try:
-            pidfile = open(op.pidfile, 'w')
-            pidfile.write(str(os.getpid()))
-            pidfile.close()
-        except Exception as e:
-            print('Failed to create pidfile %s: %s' % (op.pidfile, e), file=sys.stderr)
-            op.pidfile = False
 
     ### Empty ansi and theme database if no colors are requested
     if not op.color:


### PR DESCRIPTION
## Summary

- remove the undocumented `--pidfile` option and its unused startup/cleanup code

## Problem

`--pidfile` is parsed, stored, written at startup, and removed on exit, but nothing in dool ever reads the file back. That means it provides no duplicate-instance protection, no process lookup support, and no documented integration point. The option is also absent from the user-facing help, so it is effectively dead code.

## Changes

- remove `pidfile=` from the accepted parameter options
- remove `--pidfile` option handling from argument parsing
- remove pidfile creation during startup
- remove pidfile cleanup during exit
