### PR TITLE
Escape double quotes in CSV command header

### DIFF
--- a/dool
+++ b/dool
@@ -2826,7 +2826,7 @@ def main():
         header = ('"Host:"','"%s"' % hostname,'','','','"User:"','"%s"\n' % user)
         outputfile.write(char['sep'].join(header))
 
-        run_cmd = " ".join(sys.argv)
+        run_cmd = " ".join(sys.argv).replace('"', '""')
 
         header = ('"Cmdline:"','"' + run_cmd + '"','','','','"Date:"','"%s"\n' % time.strftime('%d %b %Y %H:%M:%S %Z', time.localtime()))
         outputfile.write(char['sep'].join(header))


### PR DESCRIPTION
## Summary

- escape embedded double quotes in the CSV `Cmdline:` header field

## Problem

The CSV header wraps the full command line in double quotes but does not escape inner `"` characters. That produces malformed CSV whenever an argument contains a literal quote, which breaks strict parsers and can garble spreadsheet imports.

## Changes

- escape `"` as `""` before writing the quoted `Cmdline:` field
