### PR TITLE
Avoid shell interpolation in MySQL and Squid plugins

### DIFF
--- a/plugins/dool_innodb_buffer.py
+++ b/plugins/dool_innodb_buffer.py
@@ -1,7 +1,10 @@
+import shlex
+import subprocess
+
 ### Author: Dag Wieers <dag$wieers,com>, Ming-Hung Chen <minghung.chen@gmail.com>
 
 global mysql_options
-mysql_options = os.getenv('DOOL_MYSQL', '')
+mysql_options = shlex.split(os.getenv('DOOL_MYSQL', ''))
 
 class dool_plugin(dool):
     def __init__(self):
@@ -16,7 +19,14 @@ class dool_plugin(dool):
         if not os.access('/usr/bin/mysql', os.X_OK):
             raise Exception('Needs MySQL binary')
         try:
-            self.stdin, self.stdout, self.stderr = dpopen('/usr/bin/mysql -n %s' % mysql_options)
+            p = subprocess.Popen(
+                ['/usr/bin/mysql', '-n'] + mysql_options,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                close_fds=True,
+            )
+            self.stdin, self.stdout, self.stderr = p.stdin, p.stdout, p.stderr
             checkerrpipe(self.stderr, '.+')
         except IOError as e:
             raise Exception('Cannot interface with MySQL binary (%s)' % e)

--- a/plugins/dool_innodb_io.py
+++ b/plugins/dool_innodb_io.py
@@ -1,7 +1,10 @@
+import shlex
+import subprocess
+
 ### Author: Dag Wieers <dag$wieers,com>, Ming-Hung Chen <minghung.chen@gmail.com>
 
 global mysql_options
-mysql_options = os.getenv('DOOL_MYSQL', '')
+mysql_options = shlex.split(os.getenv('DOOL_MYSQL', ''))
 
 class dool_plugin(dool):
     def __init__(self):
@@ -15,7 +18,14 @@ class dool_plugin(dool):
     def check(self):
         if os.access('/usr/bin/mysql', os.X_OK):
             try:
-                self.stdin, self.stdout, self.stderr = dpopen('/usr/bin/mysql -n %s' % mysql_options)
+                p = subprocess.Popen(
+                    ['/usr/bin/mysql', '-n'] + mysql_options,
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    close_fds=True,
+                )
+                self.stdin, self.stdout, self.stderr = p.stdin, p.stdout, p.stderr
                 checkerrpipe(self.stderr, '.+')
             except IOError:
                 raise Exception('Cannot interface with MySQL binary')

--- a/plugins/dool_innodb_ops.py
+++ b/plugins/dool_innodb_ops.py
@@ -1,7 +1,10 @@
+import shlex
+import subprocess
+
 ### Author: Dag Wieers <dag$wieers,com>, Ming-Hung Chen <minghung.chen@gmail.com>
 
 global mysql_options
-mysql_options = os.getenv('DOOL_MYSQL', '')
+mysql_options = shlex.split(os.getenv('DOOL_MYSQL', ''))
 
 class dool_plugin(dool):
     def __init__(self):
@@ -15,7 +18,14 @@ class dool_plugin(dool):
     def check(self):
         if os.access('/usr/bin/mysql', os.X_OK):
             try:
-                self.stdin, self.stdout, self.stderr = dpopen('/usr/bin/mysql -n %s' % mysql_options)
+                p = subprocess.Popen(
+                    ['/usr/bin/mysql', '-n'] + mysql_options,
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    close_fds=True,
+                )
+                self.stdin, self.stdout, self.stderr = p.stdin, p.stdout, p.stderr
                 checkerrpipe(self.stderr, '.+')
             except IOError:
                 raise Exception('Cannot interface with MySQL binary')

--- a/plugins/dool_mysql_innodb.py
+++ b/plugins/dool_mysql_innodb.py
@@ -1,7 +1,10 @@
+import shlex
+import subprocess
+
 ### Author: HIROSE Masaaki <hirose31 _at_ gmail.com>, Ming-Hung Chen <minghung.chen@gmail.com>
 
 global mysql_options
-mysql_options = os.getenv('DOOL_MYSQL', '')
+mysql_options = shlex.split(os.getenv('DOOL_MYSQL', ''))
 
 global target_status
 global _basic_status
@@ -82,7 +85,14 @@ class dool_plugin(dool):
 
         if mysql_cmd:
             try:
-                self.stdin, self.stdout, self.stderr = dpopen('%s -n %s' % (mysql_cmd, mysql_options))
+                p = subprocess.Popen(
+                    [mysql_cmd, '-n'] + mysql_options,
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    close_fds=True,
+                )
+                self.stdin, self.stdout, self.stderr = p.stdin, p.stdout, p.stderr
                 checkerrpipe(self.stderr, '.+')
             except IOError:
                 raise Exception('Cannot interface with MySQL binary')
@@ -119,4 +129,3 @@ class dool_plugin(dool):
         except Exception as e:
             if op.debug > 1: print('%s: exception' % (self.filename, e))
             for name in self.vars: self.val[name] = -1
-

--- a/plugins/dool_squid.py
+++ b/plugins/dool_squid.py
@@ -1,3 +1,6 @@
+import shlex
+import subprocess
+
 ### Authority: Jason Friedland <thesuperjason@gmail.com>
 
 # This plugin has been tested with:
@@ -7,7 +10,7 @@
 # - Squid 2.6 and 2.7
  
 global squidclient_options
-squidclient_options = os.getenv('DOOL_SQUID_OPTS') # -p 8080
+squidclient_options = shlex.split(os.getenv('DOOL_SQUID_OPTS') or '') # -p 8080
  
 class dool_plugin(dool):
     '''
@@ -32,12 +35,23 @@ class dool_plugin(dool):
     def check(self):
         if not os.access('/usr/sbin/squidclient', os.X_OK):
             raise Exception('Needs squidclient binary')
-        cmd_test('/usr/sbin/squidclient %s mgr:info' % squidclient_options)
+        r = subprocess.run(
+            ['/usr/sbin/squidclient'] + squidclient_options + ['mgr:info'],
+            capture_output=True,
+            text=True,
+        )
+        if r.returncode != 0 and r.stderr:
+            raise Exception(r.stderr.strip())
         return True
  
     def extract(self):
         try:
-            for l in cmd_splitlines('/usr/sbin/squidclient %s mgr:info' % squidclient_options, ':'):
+            r = subprocess.run(
+                ['/usr/sbin/squidclient'] + squidclient_options + ['mgr:info'],
+                capture_output=True,
+                text=True,
+            )
+            for l in [line.split(':') for line in r.stdout.splitlines()]:
                 if l[0].strip() in self.vars:
                     self.val[l[0].strip()] = l[1].strip()
                     break


### PR DESCRIPTION
## Summary

- parse `DOOL_MYSQL` with `shlex.split()` and pass MySQL commands as argument lists
- parse `DOOL_SQUID_OPTS` with `shlex.split()` and execute `squidclient` directly without shell interpolation

## Problem

Several MySQL/InnoDB plugins and the Squid plugin splice environment-derived option strings directly into shell command strings. That is fragile even outside of a security context: spaces and shell metacharacters can silently change argument parsing and break otherwise valid option values.

## Changes

- replace string interpolation into MySQL command strings with argument-list execution
- replace string interpolation into Squid command strings with argument-list execution
- parse plugin option environment variables with `shlex.split()`
